### PR TITLE
Featur/11 サイドナビゲーションUI、ドロワー機能の実装

### DIFF
--- a/src/app/animations/animations.ts
+++ b/src/app/animations/animations.ts
@@ -1,0 +1,60 @@
+import {
+  trigger,
+  state,
+  style,
+  transition,
+  animate,
+  animateChild,
+  query,
+} from '@angular/animations';
+
+export const onDrawerChange = trigger('onDrawerChange', [
+  state(
+    'close',
+    style({
+      'min-width': '72px',
+    })
+  ),
+  state(
+    'open',
+    style({
+      'min-width': '240px',
+    })
+  ),
+]);
+
+export const onMainContentChange = trigger('onMainContentChange', [
+  state(
+    'close',
+    style({
+      'margin-left': '62px',
+    })
+  ),
+  state(
+    'open',
+    style({
+      'margin-left': '200px',
+    })
+  ),
+  transition('close => open', animate('250ms ease-in')),
+  transition('open => close', animate('250ms ease-in')),
+]);
+
+export const animateText = trigger('animateText', [
+  state(
+    'hide',
+    style({
+      display: 'none',
+      opacity: 0,
+    })
+  ),
+  state(
+    'show',
+    style({
+      display: 'block',
+      opacity: 1,
+    })
+  ),
+  transition('close => open', animate('350ms ease-in')),
+  transition('open => close', animate('200ms ease-out')),
+]);

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,2 +1,20 @@
 <app-header></app-header>
-<router-outlet></router-outlet>
+
+<mat-sidenav-container>
+  <mat-sidenav
+    color="basic"
+    #sidenav
+    fixedInViewport
+    fixedTopGap="64"
+    mode="side"
+    opened
+  >
+    <app-drawer></app-drawer>
+  </mat-sidenav>
+
+  <mat-sidenav-content
+    [@onMainContentChange]="onDrawerChange ? 'open' : 'close'"
+  >
+    <router-outlet></router-outlet>
+  </mat-sidenav-content>
+</mat-sidenav-container>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -7,7 +7,7 @@
     fixedInViewport
     fixedTopGap="64"
     mode="side"
-    opened
+    [opened]="isOpened$ | async"
   >
     <app-drawer></app-drawer>
   </mat-sidenav>

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -1,0 +1,3 @@
+.mat-drawer {
+  background-color: #212121;
+}

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,10 +1,20 @@
 import { Component } from '@angular/core';
+import { DrawerService } from './services/drawer.service';
+import { onMainContentChange } from './animations/animations';
 
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',
-  styleUrls: ['./app.component.scss']
+  styleUrls: ['./app.component.scss'],
+  animations: [onMainContentChange],
 })
 export class AppComponent {
   title = 'note-for-youtube';
+  onDrawerChange: boolean;
+  constructor(private drawerService: DrawerService) {
+    this.drawerService.drawerState$.subscribe((res) => {
+      console.log(res);
+      this.onDrawerChange = res;
+    });
+  }
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 import { DrawerService } from './services/drawer.service';
 import { onMainContentChange } from './animations/animations';
+import { Observable } from 'rxjs';
 
 @Component({
   selector: 'app-root',
@@ -10,6 +11,9 @@ import { onMainContentChange } from './animations/animations';
 })
 export class AppComponent {
   title = 'note-for-youtube';
+
+  isOpened$: Observable<boolean> = this.drawerService.isOpened$;
+
   onDrawerChange: boolean;
   constructor(private drawerService: DrawerService) {
     this.drawerService.drawerState$.subscribe((res) => {

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,25 +1,26 @@
 import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
-
-import { AppRoutingModule } from './app-routing.module';
-import { AppComponent } from './app.component';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { HeaderComponent } from './header/header.component';
+import { AppRoutingModule } from './app-routing.module';
+import { AngularMaterialModule } from './shared/angular-material.module';
+import { MatSidenavModule } from '@angular/material/sidenav';
+import { MatListModule } from '@angular/material/list';
 import { MatToolbarModule } from '@angular/material/toolbar';
-import { MatIconModule } from '@angular/material/icon';
-import { MatButtonModule } from '@angular/material/button';
-import { MatInputModule } from '@angular/material/input';
+
+import { AppComponent } from './app.component';
+import { HeaderComponent } from './header/header.component';
+import { DrawerComponent } from './drawer/drawer.component';
 
 @NgModule({
-  declarations: [AppComponent, HeaderComponent],
+  declarations: [AppComponent, HeaderComponent, DrawerComponent],
   imports: [
     BrowserModule,
     AppRoutingModule,
     BrowserAnimationsModule,
+    AngularMaterialModule,
+    MatSidenavModule,
+    MatListModule,
     MatToolbarModule,
-    MatIconModule,
-    MatButtonModule,
-    MatInputModule,
   ],
   providers: [],
   bootstrap: [AppComponent],

--- a/src/app/drawer/drawer.component.html
+++ b/src/app/drawer/drawer.component.html
@@ -1,0 +1,39 @@
+<div
+  class="sidenav_container"
+  [@onDrawerChange]="drawerState ? 'open' : 'close'"
+>
+  <mat-nav-list class="nav__side-list" [class.closed]="!drawerState">
+    <mat-list-item *ngFor="let page of pages">
+      <mat-icon mat-list-icon *ngIf="drawerState">{{ page?.icon }}</mat-icon>
+      <mat-icon mat-list-icon *ngIf="!drawerState">{{ page?.icon }}</mat-icon>
+      <span matLine [@animateText]="linkText ? 'show' : 'hide'"
+        >{{ page?.name }}
+      </span>
+    </mat-list-item>
+  </mat-nav-list>
+
+  <span class="spacer"></span>
+  <div class="nav__side-arrow">
+    <button mat-icon-button (click)="onToggle()">
+      <mat-icon *ngIf="drawerState">arrow_left</mat-icon>
+      <mat-icon *ngIf="!drawerState">arrow_right</mat-icon>
+    </button>
+  </div>
+
+  <div *ngIf="drawerState">
+    <mat-divider></mat-divider>
+    <ul class="nav__footer-list">
+      <li>
+        <a class="nav__footer-subscribe" routerLink="/">
+          アップグレード
+          <mat-icon inline="true">whatshot</mat-icon>
+        </a>
+      </li>
+      <li><a class="nav__footer-link" routerLink="/">サービス紹介</a></li>
+      <li><a class="nav__footer-link" routerLink="/">利用規約</a></li>
+      <li>
+        <a class="nav__footer-link" routerLink="/">特定商取引法に基づく表示</a>
+      </li>
+    </ul>
+  </div>
+</div>

--- a/src/app/drawer/drawer.component.html
+++ b/src/app/drawer/drawer.component.html
@@ -1,7 +1,4 @@
-<div
-  class="sidenav_container"
-  [@onDrawerChange]="drawerState ? 'open' : 'close'"
->
+<div class="nav__container" [@onDrawerChange]="drawerState ? 'open' : 'close'">
   <mat-nav-list class="nav__side-list" [class.closed]="!drawerState">
     <mat-list-item *ngFor="let page of pages">
       <mat-icon mat-list-icon *ngIf="drawerState">{{ page?.icon }}</mat-icon>
@@ -20,7 +17,7 @@
     </button>
   </div>
 
-  <div *ngIf="drawerState">
+  <div class="nav__footer" *ngIf="drawerState">
     <mat-divider></mat-divider>
     <ul class="nav__footer-list">
       <li>

--- a/src/app/drawer/drawer.component.scss
+++ b/src/app/drawer/drawer.component.scss
@@ -1,0 +1,23 @@
+.nav {
+  &__side-arrow {
+    padding: 0 16px 16px 16px;
+  }
+  &__footer-list {
+    display: flex;
+    list-style: none;
+    padding: 0 24px;
+    flex-direction: column;
+  }
+  &__footer-link {
+    font-size: 13px;
+    color: #9e9e9e;
+    text-decoration: none;
+  }
+  &__footer-subscribe {
+    font-size: 16px;
+    text-decoration: none;
+    color: white;
+    display: flex;
+    align-items: center;
+  }
+}

--- a/src/app/drawer/drawer.component.spec.ts
+++ b/src/app/drawer/drawer.component.spec.ts
@@ -1,0 +1,24 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DrawerComponent } from './drawer.component';
+
+describe('DrawerComponent', () => {
+  let component: DrawerComponent;
+  let fixture: ComponentFixture<DrawerComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [DrawerComponent],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DrawerComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/drawer/drawer.component.ts
+++ b/src/app/drawer/drawer.component.ts
@@ -1,0 +1,35 @@
+import { Component, OnInit } from '@angular/core';
+import { onDrawerChange, animateText } from '../animations/animations';
+import { DrawerService } from '../services/drawer.service';
+
+interface Page {
+  link: string;
+  name: string;
+  icon: string;
+}
+@Component({
+  selector: 'app-drawer',
+  templateUrl: './drawer.component.html',
+  styleUrls: ['./drawer.component.scss'],
+  animations: [onDrawerChange, animateText],
+})
+export class DrawerComponent implements OnInit {
+  constructor(private drawerService: DrawerService) {}
+  pages: Page[] = [
+    { name: 'ホーム', link: 'some-link', icon: 'home' },
+    { name: 'マイリスト', link: 'some-link', icon: 'list' },
+    { name: 'ブックマーク', link: 'some-link', icon: 'book' },
+    { name: 'タグ', link: 'some-link', icon: 'loyalty' },
+  ];
+
+  drawerState = false;
+  linkText = false;
+  onToggle() {
+    this.drawerState = !this.drawerState;
+    setTimeout(() => {
+      this.linkText = this.drawerState;
+    });
+    this.drawerService.drawerState$.next(this.drawerState);
+  }
+  ngOnInit() {}
+}

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -1,7 +1,7 @@
 <header class="header">
   <mat-toolbar class="header__toolbar" color="bacic">
     <div class="header__left">
-      <button mat-icon-button>
+      <button mat-icon-button (click)="toggle()">
         <mat-icon>menu</mat-icon>
       </button>
       <img class="header__image" src="./assets/images/NFT-LOGO.png" alt="" />

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -1,7 +1,7 @@
 <header class="header">
-  <mat-toolbar class="header__toolbar" color="basic">
+  <mat-toolbar class="header__toolbar" color="bacic">
     <div class="header__left">
-      <button mat-icon-button aria-label="Example icon button with a menu icon">
+      <button mat-icon-button>
         <mat-icon>menu</mat-icon>
       </button>
       <img class="header__image" src="./assets/images/NFT-LOGO.png" alt="" />

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, Input } from '@angular/core';
 
 @Component({
   selector: 'app-header',

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -1,4 +1,5 @@
-import { Component, OnInit, Input } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { DrawerService } from '../services/drawer.service';
 
 @Component({
   selector: 'app-header',
@@ -6,7 +7,11 @@ import { Component, OnInit, Input } from '@angular/core';
   styleUrls: ['./header.component.scss'],
 })
 export class HeaderComponent implements OnInit {
-  constructor() {}
+  constructor(private drawerService: DrawerService) {}
 
   ngOnInit(): void {}
+
+  toggle() {
+    this.drawerService.toggle();
+  }
 }

--- a/src/app/services/drawer.service.spec.ts
+++ b/src/app/services/drawer.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { DrawerService } from './drawer.service';
+
+describe('DrawerService', () => {
+  let service: DrawerService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(DrawerService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/drawer.service.ts
+++ b/src/app/services/drawer.service.ts
@@ -1,0 +1,11 @@
+import { Injectable } from '@angular/core';
+import { Subject, Observable, ReplaySubject } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class DrawerService {
+  drawerState$: Subject<boolean> = new Subject();
+
+  constructor() {}
+}

--- a/src/app/services/drawer.service.ts
+++ b/src/app/services/drawer.service.ts
@@ -1,11 +1,19 @@
 import { Injectable } from '@angular/core';
-import { Subject, Observable, ReplaySubject } from 'rxjs';
+import { Subject, ReplaySubject } from 'rxjs';
 
 @Injectable({
   providedIn: 'root',
 })
 export class DrawerService {
+  drawerSource = new ReplaySubject<boolean>(1);
+  isOpened$ = this.drawerSource.asObservable();
+  isOpend: boolean;
+
   drawerState$: Subject<boolean> = new Subject();
 
   constructor() {}
+  toggle() {
+    this.isOpend = !this.isOpend;
+    this.drawerSource.next(this.isOpend);
+  }
 }

--- a/src/app/shared/angular-material.module.ts
+++ b/src/app/shared/angular-material.module.ts
@@ -1,0 +1,18 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+
+const materialModules = [
+  MatIconModule,
+  MatFormFieldModule,
+  MatButtonModule,
+  CommonModule,
+];
+
+@NgModule({
+  imports: [...materialModules],
+  exports: [...materialModules],
+})
+export class AngularMaterialModule {}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,10 +1,6 @@
 /* You can add global styles to this file, and also import other style files */
 @import '~@fortawesome/fontawesome-free/css/all.css';
 
-* {
-  box-sizing: border-box;
-}
-
 html,
 body {
   height: 100%;
@@ -21,4 +17,11 @@ img {
 
 .container {
   padding: 0 24px;
+}
+
+.closed .mat-list-text {
+  padding-left: 0 !important;
+}
+.nav__side-list .mat-list-item-content {
+  padding: 20px !important;
 }


### PR DESCRIPTION
fix #11 
サイドナビゲーション実装しました。
以下の作業内容で実装しましたので、ご確認よろしくお願い致します。

## 実装内容
-  各ページ遷移ボタンのリスト(｛ホーム｝、｛マイリスト｝、｛ブックマーク｝、｛タグ｝、｛mini variant切替ボタン｝)を追加
-  アップグレード、サービス紹介、利用規約、特定商取引法に基づく表示へのリンク
-  routingは各ページ作成時実装します
-  ヘッダーのメニューボタンでのドロワー機能、nav-list内のarrowボタンでmini variant切替機能の実装
## image
https://gyazo.com/3ecf1eed9ad668edf0afcebdf2859356