### PR TITLE
Feature/54 ログイン時にSNSアカウントの情報をFirestoreに追加して表示させる

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -2,7 +2,7 @@ rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
     match /{document=**} {
-      allow read, write: if false;
+      allow read, write: if request.auth.uid != null;
     }
   }
 }

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -297,9 +297,9 @@
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.17.7",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.7.tgz",
-      "integrity": "sha512-EMgTj/DF9qpgLXyc+Btimg+XoH7A2liE8uKul8qSmMTHCeNYzydDKFdsJskDvw42UsesCnhO63dO0Grbj8J4Dw==",
+      "version": "4.17.8",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.8.tgz",
+      "integrity": "sha512-1SJZ+R3Q/7mLkOD9ewCBDYD2k0WyZQtWYqF/2VvoNN2/uhI49J9CDN4OAm+wGMA0DbArA4ef27xl4+JwMtGggw==",
       "requires": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -977,9 +977,9 @@
       }
     },
     "firebase-functions": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-3.7.0.tgz",
-      "integrity": "sha512-+ROj2Gs2/KyM+T8jYo7AKaHynFsN49sXbgZMll3zuGa9/8oiDsXp9e1Iy2JMkFmSZg67jeYw5Ue2OSpz0XiqFQ==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-3.8.0.tgz",
+      "integrity": "sha512-RFvoS7ZcXrk2sQ918czsjv94p4hnSoD0/e4cZ86XFpa1HbNZBI7ZuSgBCzRvlv6dJ1ArytAL13NpB1Bp2tJ6Yg==",
       "requires": {
         "@types/express": "4.17.3",
         "cors": "^2.8.5",

--- a/functions/package.json
+++ b/functions/package.json
@@ -15,7 +15,7 @@
   "main": "lib/index.js",
   "dependencies": {
     "firebase-admin": "^8.10.0",
-    "firebase-functions": "^3.6.1"
+    "firebase-functions": "^3.8.0"
   },
   "devDependencies": {
     "tslint": "^5.12.0",

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,8 +1,6 @@
-//import * as functions from 'firebase-functions';
+import * as functions from 'firebase-functions';
+import * as admin from 'firebase-admin';
 
-// // Start writing Firebase Functions
-// // https://firebase.google.com/docs/functions/typescript
-//
-// export const helloWorld = functions.https.onRequest((request, response) => {
-//  response.send("Hello from Firebase!");
-// });
+admin.initializeApp(functions.config().firebase);
+
+export * from './user.function';

--- a/functions/src/intarfaces/user.ts
+++ b/functions/src/intarfaces/user.ts
@@ -1,0 +1,7 @@
+export interface UserData {
+  uid: string;
+  name: string;
+  avatarURL: string;
+  email: string;
+  createdAt: Date;
+}

--- a/functions/src/user.function.ts
+++ b/functions/src/user.function.ts
@@ -1,0 +1,24 @@
+import * as functions from 'firebase-functions';
+import * as admin from 'firebase-admin';
+
+const db = admin.firestore();
+
+export const createUser = functions
+  .region('asia-northeast1')
+  .auth.user()
+  .onCreate((user) => {
+    return db.doc(`users/${user.uid}`).set({
+      uid: user.uid,
+      name: user.displayName,
+      avatarURL: user.photoURL,
+      email: user.email,
+      createdAt: new Date(),
+    });
+  });
+
+export const deleteUser = functions
+  .region('asia-northeast1')
+  .auth.user()
+  .onDelete((user) => {
+    return db.doc(`users/${user.uid}`).delete();
+  });

--- a/src/app/account/account/account.component.html
+++ b/src/app/account/account/account.component.html
@@ -1,1 +1,1 @@
-<p>account works!</p>
+<p *ngIf="user$ | async as user">{{ user.name }}でログイン中</p>

--- a/src/app/account/account/account.component.ts
+++ b/src/app/account/account/account.component.ts
@@ -1,4 +1,7 @@
 import { Component, OnInit } from '@angular/core';
+import { AuthService } from 'src/app/services/auth.service';
+import { Observable } from 'rxjs';
+import { UserData } from 'functions/src/intarfaces/user';
 
 @Component({
   selector: 'app-account',
@@ -6,7 +9,9 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./account.component.scss'],
 })
 export class AccountComponent implements OnInit {
-  constructor() {}
+  user$: Observable<UserData> = this.authService.user$;
+
+  constructor(private authService: AuthService) {}
 
   ngOnInit(): void {}
 }

--- a/src/app/guards/auth.guard.ts
+++ b/src/app/guards/auth.guard.ts
@@ -28,7 +28,7 @@ export class AuthGuard implements CanActivate, CanLoad {
     | Promise<boolean | UrlTree>
     | boolean
     | UrlTree {
-    return this.authService.afUser$.pipe(
+    return this.authService.user$.pipe(
       map((user) => !!user),
       tap((isLoggedIn) => {
         if (!isLoggedIn) {
@@ -41,7 +41,7 @@ export class AuthGuard implements CanActivate, CanLoad {
     route: Route,
     segments: UrlSegment[]
   ): Observable<boolean> | Promise<boolean> | boolean {
-    return this.authService.afUser$.pipe(
+    return this.authService.user$.pipe(
       map((user) => !!user),
       take(1),
       tap((isLoggedIn) => {

--- a/src/app/guards/guest.guard.ts
+++ b/src/app/guards/guest.guard.ts
@@ -27,7 +27,7 @@ export class GuestGuard implements CanActivate, CanLoad {
     | Promise<boolean | UrlTree>
     | boolean
     | UrlTree {
-    return this.authService.afUser$.pipe(
+    return this.authService.user$.pipe(
       map((user) => !user),
       tap((isGuest) => {
         if (!isGuest) {
@@ -40,7 +40,7 @@ export class GuestGuard implements CanActivate, CanLoad {
     route: Route,
     segments: UrlSegment[]
   ): Observable<boolean> | Promise<boolean> | boolean {
-    return this.authService.afUser$.pipe(
+    return this.authService.user$.pipe(
       map((user) => !user),
       take(1),
       tap((isGuest) => {

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -27,26 +27,27 @@
         <mat-icon>notifications</mat-icon>
       </button>
 
-      <button
-        *ngIf="user$ | async"
-        class="nav__user-avatar"
-        mat-mini-fab
-        [matMenuTriggerFor]="menu"
-        [style.background-image]="'url(./assets/images/dummy-icon.png)'"
-      ></button>
-      <mat-menu #menu="matMenu">
-        <button (click)="logout()" mat-menu-item>
-          <mat-icon>exit_to_app</mat-icon>
-          ログアウト
-        </button>
+      <div *ngIf="user$ | async as user">
+        <button
+          class="nav__user-avatar"
+          mat-mini-fab
+          [matMenuTriggerFor]="menu"
+          [style.background-image]="'url(' + user.avatarURL + ')'"
+        ></button>
+        <mat-menu #menu="matMenu">
+          <button (click)="logout()" mat-menu-item>
+            <mat-icon>exit_to_app</mat-icon>
+            ログアウト
+          </button>
 
-        <mat-divider></mat-divider>
+          <mat-divider></mat-divider>
 
-        <button mat-menu-item routerLink="/account">
-          <mat-icon>account_box</mat-icon>
-          アカウント管理
-        </button>
-      </mat-menu>
+          <a mat-menu-item routerLink="/account">
+            <mat-icon>account_box</mat-icon>
+            アカウント管理
+          </a>
+        </mat-menu>
+      </div>
     </nav>
   </mat-toolbar>
 </header>

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -8,8 +8,7 @@ import { AuthService } from '../services/auth.service';
   styleUrls: ['./header.component.scss'],
 })
 export class HeaderComponent implements OnInit {
-  user$ = this.authService.afUser$;
-
+  user$ = this.authService.user$;
   constructor(
     public drawerService: DrawerService,
     private authService: AuthService

--- a/src/app/interfaces/user.ts
+++ b/src/app/interfaces/user.ts
@@ -1,0 +1,7 @@
+export interface User {
+  uid: string;
+  name: string;
+  avatarURL: string;
+  email: string;
+  createdAt: Date;
+}

--- a/src/app/interfaces/user.ts
+++ b/src/app/interfaces/user.ts
@@ -1,7 +1,0 @@
-export interface User {
-  uid: string;
-  name: string;
-  avatarURL: string;
-  email: string;
-  createdAt: Date;
-}

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -32,7 +32,7 @@ export class AuthService {
   googleLogin() {
     const googleProvider = new auth.GoogleAuthProvider();
     googleProvider.setCustomParameters({ prompt: 'select_account' });
-    this.afAuth.signInWithPopup(googleProvider).then(() => {
+    return this.afAuth.signInWithPopup(googleProvider).then(() => {
       this.snackBar.open('ログインしました', null, {
         duration: 2000,
       });
@@ -43,7 +43,7 @@ export class AuthService {
   twitterLogin() {
     const twitterProvider = new auth.TwitterAuthProvider();
     twitterProvider.setCustomParameters({ prompt: 'select_account' });
-    this.afAuth.signInWithPopup(twitterProvider).then(() => {
+    return this.afAuth.signInWithPopup(twitterProvider).then(() => {
       this.snackBar.open('ログインしました', null, {
         duration: 2000,
       });

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -2,24 +2,32 @@ import { Injectable } from '@angular/core';
 import { AngularFireAuth } from '@angular/fire/auth';
 import { AngularFirestore } from '@angular/fire/firestore';
 import { auth, User } from 'firebase/app';
-import { Observable } from 'rxjs';
+import { Observable, of } from 'rxjs';
 import { Router } from '@angular/router';
 import { MatSnackBar } from '@angular/material/snack-bar';
+import { UserData } from 'functions/src/intarfaces/user';
+import { switchMap } from 'rxjs/operators';
 
 @Injectable({
   providedIn: 'root',
 })
 export class AuthService {
-  afUser$: Observable<User> = this.afAuth.user;
+  user$: Observable<UserData> = this.afAuth.authState.pipe(
+    switchMap((afUser) => {
+      if (afUser) {
+        return this.db.doc<UserData>(`users/${afUser.uid}`).valueChanges();
+      } else {
+        return of(null);
+      }
+    })
+  );
 
   constructor(
     public afAuth: AngularFireAuth,
     private db: AngularFirestore,
     private router: Router,
     private snackBar: MatSnackBar
-  ) {
-    this.afUser$.subscribe((user) => console.log(user));
-  }
+  ) {}
 
   googleLogin() {
     const googleProvider = new auth.GoogleAuthProvider();

--- a/src/app/welcome/welcome/welcome.component.html
+++ b/src/app/welcome/welcome/welcome.component.html
@@ -1,3 +1,7 @@
 <p>welcome works!</p>
-<button (click)="googleLogin()" mat-raised-button>Googleログイン</button>
-<button (click)="twitterLogin()" mat-raised-button>Twitterログイン</button>
+<button (click)="googleLogin()" mat-raised-button [disabled]="googleLogging">
+  {{ googleLogging ? 'ログイン中' : 'Googleログイン' }}
+</button>
+<button (click)="twitterLogin()" mat-raised-button [disabled]="twitterLogging">
+  {{ twitterLogging ? 'ログイン中' : 'Twitterログイン' }}
+</button>

--- a/src/app/welcome/welcome/welcome.component.ts
+++ b/src/app/welcome/welcome/welcome.component.ts
@@ -7,15 +7,23 @@ import { AuthService } from 'src/app/services/auth.service';
   styleUrls: ['./welcome.component.scss'],
 })
 export class WelcomeComponent implements OnInit {
+  googleLogging: boolean;
+  twitterLogging: boolean;
   constructor(private authService: AuthService) {}
 
   ngOnInit(): void {}
 
   googleLogin() {
-    this.authService.googleLogin();
+    this.googleLogging = true;
+    this.authService.googleLogin().finally(() => {
+      this.googleLogging = false;
+    });
   }
 
   twitterLogin() {
-    this.authService.twitterLogin();
+    this.twitterLogging = true;
+    this.authService.twitterLogin().finally(() => {
+      this.twitterLogging = false;
+    });
   }
 }


### PR DESCRIPTION
fix #54  
Firestoreにユーザー情報の追加、表示とそれに伴う修正の実装をしました。
以下の作業内容で実装しましたので、ご確認よろしくお願い致します。

## 実装内容
- SNSアカウントのユーザーデータをログイン時に、firestoreに追加する
- 追加したユーザーのavatarURLをヘッダーに表示
- ユーザーのSNS名をavatar.component.htmlで表示
- ログイン中にログインボタンを『ログイン中』にし、クリック出来ない処理
# image
<a href="https://gyazo.com/3d35ea2b9cf645b0f916297e1d6b2d72"><img src="https://i.gyazo.com/3d35ea2b9cf645b0f916297e1d6b2d72.gif" alt="Image from Gyazo" width="1000"/></a>