### PR TITLE
Featuer/21 マイリスト作成機能の実装

### DIFF
--- a/functions/src/intarfaces/play-list.ts
+++ b/functions/src/intarfaces/play-list.ts
@@ -1,0 +1,11 @@
+import { firestore } from 'firebase-admin';
+
+export interface PlayList {
+  id: string;
+  creatorId: string;
+  listName: string;
+  listText?: string;
+  privacy: string;
+  createdAt: firestore.Timestamp;
+  updateAt: firestore.Timestamp;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10205,9 +10205,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
     },
     "lodash._isnative": {
       "version": "2.4.1",
@@ -11283,9 +11283,9 @@
       }
     },
     "npm-registry-fetch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-4.0.4.tgz",
-      "integrity": "sha512-6jb34hX/iYNQebqWUHtU8YF6Cjb1H6ouTFPClYsyiW6lpFkljTpdeftm53rRojtja1rKAvKNIIiTS5Sjpw4wsA==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-4.0.5.tgz",
+      "integrity": "sha512-yQ0/U4fYpCCqmueB2g8sc+89ckQ3eXpmU4+Yi2j5o/r0WkKvE2+Y0tK3DEILAtn2UaQTkjTHxIXe2/CSdit+/Q==",
       "dev": true,
       "requires": {
         "JSONStream": "^1.3.4",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,27 +1,47 @@
 import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
+import { environment } from '../environments/environment';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { AppRoutingModule } from './app-routing.module';
-import { AngularMaterialModule } from './shared/angular-material.module';
-import { MatSidenavModule } from '@angular/material/sidenav';
-import { MatListModule } from '@angular/material/list';
-import { MatToolbarModule } from '@angular/material/toolbar';
 import { AngularFireAnalyticsModule } from '@angular/fire/analytics';
 import { AngularFirestoreModule } from '@angular/fire/firestore';
 import { AngularFireStorageModule } from '@angular/fire/storage';
 import { AngularFireFunctionsModule, REGION } from '@angular/fire/functions';
 import { AngularFireAuthModule } from '@angular/fire/auth';
-import { MatMenuModule } from '@angular/material/menu';
-import { MatSnackBarModule } from '@angular/material/snack-bar';
+import { AngularFireModule } from '@angular/fire';
+import { FormsModule } from '@angular/forms';
+import { ReactiveFormsModule } from '@angular/forms';
 
 import { AppComponent } from './app.component';
 import { HeaderComponent } from './header/header.component';
 import { DrawerComponent } from './drawer/drawer.component';
 import { NotFoundComponent } from './not-found/not-found.component';
 import { MiniVariantComponent } from './mini-variant/mini-variant.component';
-import { AngularFireModule } from '@angular/fire';
-import { environment } from '../environments/environment';
+import { CreateListComponent } from './create-list/create-list.component';
 
+import { AngularMaterialModule } from './shared/angular-material.module';
+import { MatMenuModule } from '@angular/material/menu';
+import { MatSnackBarModule } from '@angular/material/snack-bar';
+import { MatToolbarModule } from '@angular/material/toolbar';
+import { MatSidenavModule } from '@angular/material/sidenav';
+import { MatListModule } from '@angular/material/list';
+import { MatInputModule } from '@angular/material/input';
+import { MatOptionModule } from '@angular/material/core';
+import { MatSelectModule } from '@angular/material/select';
+import { MatTooltipModule } from '@angular/material/tooltip';
+
+const materialModule = [
+  AngularMaterialModule,
+  MatMenuModule,
+  MatSnackBarModule,
+  MatInputModule,
+  MatSidenavModule,
+  MatListModule,
+  MatToolbarModule,
+  MatOptionModule,
+  MatSelectModule,
+  MatTooltipModule,
+];
 @NgModule({
   declarations: [
     AppComponent,
@@ -29,25 +49,24 @@ import { environment } from '../environments/environment';
     DrawerComponent,
     NotFoundComponent,
     MiniVariantComponent,
+    CreateListComponent,
   ],
   imports: [
+    ...materialModule,
     BrowserModule,
     AngularFireModule.initializeApp(environment.firebase),
     AppRoutingModule,
     BrowserAnimationsModule,
-    AngularMaterialModule,
-    MatSidenavModule,
-    MatListModule,
-    MatToolbarModule,
     AngularFireAnalyticsModule,
     AngularFirestoreModule,
     AngularFireStorageModule,
     AngularFireFunctionsModule,
     AngularFireAuthModule,
-    MatMenuModule,
-    MatSnackBarModule,
+    FormsModule,
+    ReactiveFormsModule,
   ],
   providers: [{ provide: REGION, useValue: 'asia-northeast1' }],
   bootstrap: [AppComponent],
+  entryComponents: [CreateListComponent],
 })
 export class AppModule {}

--- a/src/app/create-list/create-list.component.html
+++ b/src/app/create-list/create-list.component.html
@@ -12,7 +12,18 @@
           placeholder="マイリストの名前を入力"
           autocomplete="off"
           required
+          [(ngModel)]="value"
         />
+        <button
+          mat-button
+          *ngIf="value"
+          matSuffix
+          mat-icon-button
+          aria-label="Clear"
+          (click)="value = ''"
+        >
+          <mat-icon>close</mat-icon>
+        </button>
         <mat-error *ngIf="listName.hasError('required')"
           >必須入力です</mat-error
         >

--- a/src/app/create-list/create-list.component.html
+++ b/src/app/create-list/create-list.component.html
@@ -1,0 +1,55 @@
+<div class="create-list">
+  <h1 class="create-list__title" matDialogTitle>マイリスト作成</h1>
+
+  <mat-dialog-content>
+    <form [formGroup]="form">
+      <mat-form-field class="create-list__input" appearance="outline">
+        <mat-label>名前</mat-label>
+        <input
+          formControlName="listName"
+          matInput
+          #message
+          placeholder="マイリストの名前を入力"
+          autocomplete="off"
+          required
+        />
+        <mat-error *ngIf="listName.hasError('required')"
+          >必須入力です</mat-error
+        >
+        <mat-error *ngIf="listName.hasError('maxlength')"
+          >最大150文字です</mat-error
+        >
+        <mat-hint align="end">{{ message.value.length }} / 150</mat-hint>
+      </mat-form-field>
+    </form>
+    <mat-form-field [formGroup]="form" class="create-list__selector">
+      <mat-label>プライバシー設定</mat-label>
+      <mat-select-trigger> </mat-select-trigger>
+      <mat-select formControlName="privacy" required>
+        <mat-option value="public">
+          公開
+        </mat-option>
+        <mat-option value="limited">
+          限定公開
+        </mat-option>
+        <mat-option value="private">
+          非公開
+        </mat-option>
+      </mat-select>
+      <mat-error *ngIf="listName.hasError('required')">必須選択です</mat-error>
+    </mat-form-field>
+  </mat-dialog-content>
+
+  <mat-dialog-actions class="create-list__btn">
+    <button mat-button matDialogClose>キャンセル</button>
+    <button
+      (click)="createPlayList()"
+      color="accent"
+      mat-raised-button
+      mat-button
+      [disabled]="form.invalid || form.pristine"
+    >
+      作成
+    </button>
+  </mat-dialog-actions>
+</div>

--- a/src/app/create-list/create-list.component.html
+++ b/src/app/create-list/create-list.component.html
@@ -8,7 +8,6 @@
         <input
           formControlName="listName"
           matInput
-          #message
           placeholder="マイリストの名前を入力"
           autocomplete="off"
           required
@@ -30,7 +29,7 @@
         <mat-error *ngIf="listName.hasError('maxlength')"
           >最大150文字です</mat-error
         >
-        <mat-hint align="end">{{ message.value.length }} / 150</mat-hint>
+        <mat-hint align="end">{{ listName.value.length }} / 150</mat-hint>
       </mat-form-field>
     </form>
     <mat-form-field [formGroup]="form" class="create-list__selector">

--- a/src/app/create-list/create-list.component.scss
+++ b/src/app/create-list/create-list.component.scss
@@ -1,0 +1,16 @@
+.create-list {
+  &__title {
+    margin-bottom: 24px;
+  }
+  &__input {
+    width: 100%;
+    margin-bottom: 24px;
+  }
+  &__selector {
+    width: 100%;
+  }
+  &__btn {
+    display: flex;
+    justify-content: flex-end;
+  }
+}

--- a/src/app/create-list/create-list.component.spec.ts
+++ b/src/app/create-list/create-list.component.spec.ts
@@ -1,0 +1,24 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CreateListComponent } from './create-list.component';
+
+describe('CreateListComponent', () => {
+  let component: CreateListComponent;
+  let fixture: ComponentFixture<CreateListComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [CreateListComponent],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CreateListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/create-list/create-list.component.ts
+++ b/src/app/create-list/create-list.component.ts
@@ -1,0 +1,51 @@
+import { Component, OnInit } from '@angular/core';
+import { PlayListService } from '../services/play-list.service';
+import { MatDialogRef } from '@angular/material/dialog';
+import { FormBuilder, Validators, FormControl } from '@angular/forms';
+import { PlayList } from 'functions/src/intarfaces/play-list';
+import { AuthService } from '../services/auth.service';
+import { MatSnackBar } from '@angular/material/snack-bar';
+
+@Component({
+  selector: 'app-create-list',
+  templateUrl: './create-list.component.html',
+  styleUrls: ['./create-list.component.scss'],
+})
+export class CreateListComponent implements OnInit {
+  form = this.fb.group({
+    listName: ['', [Validators.required, Validators.maxLength(150)]],
+    privacy: [
+      'public',
+      [Validators.required, Validators.pattern(/public|limited|private/)],
+    ],
+  });
+
+  get listName() {
+    return this.form.get('listName') as FormControl;
+  }
+  constructor(
+    private playListService: PlayListService,
+    private dialog: MatDialogRef<CreateListComponent>,
+    private fb: FormBuilder,
+    private authService: AuthService,
+    private snackBar: MatSnackBar
+  ) {}
+
+  ngOnInit(): void {}
+
+  createPlayList(): Promise<void> {
+    const formData = this.form.value;
+    const newValue: Omit<PlayList, 'id' | 'createdAt' | 'updateAt'> = {
+      listName: formData.listName,
+      privacy: formData.privacy,
+      creatorId: this.authService.uid,
+      listText: '',
+    };
+    return this.playListService.createPlayList(newValue).then(() => {
+      this.dialog.close();
+      this.snackBar.open('マイリストを作成しました😎', null, {
+        duration: 2000,
+      });
+    });
+  }
+}

--- a/src/app/create-list/create-list.component.ts
+++ b/src/app/create-list/create-list.component.ts
@@ -12,6 +12,7 @@ import { MatSnackBar } from '@angular/material/snack-bar';
   styleUrls: ['./create-list.component.scss'],
 })
 export class CreateListComponent implements OnInit {
+  value = '';
   form = this.fb.group({
     listName: ['', [Validators.required, Validators.maxLength(150)]],
     privacy: [

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -28,12 +28,11 @@
         (click)="openCreateList()"
         mat-icon-button
         matTooltip="マイリストの追加"
-        aria-label="Button that displays a tooltip when focused or hovered over"
       >
         <mat-icon>add</mat-icon>
       </button>
 
-      <button mat-icon-button aria-label="Example icon button with a menu icon">
+      <button mat-icon-button>
         <mat-icon>notifications</mat-icon>
       </button>
 

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -23,6 +23,16 @@
     </div>
 
     <nav class="nav">
+      <button
+        class="nav__create-btn"
+        (click)="openCreateList()"
+        mat-icon-button
+        matTooltip="マイリストの追加"
+        aria-label="Button that displays a tooltip when focused or hovered over"
+      >
+        <mat-icon>add</mat-icon>
+      </button>
+
       <button mat-icon-button aria-label="Example icon button with a menu icon">
         <mat-icon>notifications</mat-icon>
       </button>

--- a/src/app/header/header.component.scss
+++ b/src/app/header/header.component.scss
@@ -75,4 +75,7 @@
     background: center / cover;
     margin-left: 16px;
   }
+  &__create-btn {
+    margin-right: 4px;
+  }
 }

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -1,6 +1,8 @@
 import { Component, OnInit } from '@angular/core';
 import { DrawerService } from '../services/drawer.service';
 import { AuthService } from '../services/auth.service';
+import { MatDialog } from '@angular/material/dialog';
+import { CreateListComponent } from '../create-list/create-list.component';
 
 @Component({
   selector: 'app-header',
@@ -11,7 +13,8 @@ export class HeaderComponent implements OnInit {
   user$ = this.authService.user$;
   constructor(
     public drawerService: DrawerService,
-    private authService: AuthService
+    private authService: AuthService,
+    private dialog: MatDialog
   ) {}
 
   ngOnInit(): void {}
@@ -25,5 +28,12 @@ export class HeaderComponent implements OnInit {
 
   logout() {
     this.authService.logout();
+  }
+  openCreateList() {
+    this.dialog.open(CreateListComponent, {
+      width: '640px',
+      autoFocus: false,
+      restoreFocus: false,
+    });
   }
 }

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -29,9 +29,7 @@ export class AuthService {
     private db: AngularFirestore,
     private router: Router,
     private snackBar: MatSnackBar
-  ) {
-    console.log(this.user$);
-  }
+  ) {}
 
   googleLogin() {
     const googleProvider = new auth.GoogleAuthProvider();

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -12,9 +12,11 @@ import { switchMap } from 'rxjs/operators';
   providedIn: 'root',
 })
 export class AuthService {
+  uid: string;
   user$: Observable<UserData> = this.afAuth.authState.pipe(
     switchMap((afUser) => {
       if (afUser) {
+        this.uid = afUser?.uid;
         return this.db.doc<UserData>(`users/${afUser.uid}`).valueChanges();
       } else {
         return of(null);
@@ -27,7 +29,9 @@ export class AuthService {
     private db: AngularFirestore,
     private router: Router,
     private snackBar: MatSnackBar
-  ) {}
+  ) {
+    console.log(this.user$);
+  }
 
   googleLogin() {
     const googleProvider = new auth.GoogleAuthProvider();

--- a/src/app/services/play-list.service.spec.ts
+++ b/src/app/services/play-list.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { PlayListService } from './play-list.service';
+
+describe('PlayListService', () => {
+  let service: PlayListService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(PlayListService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/play-list.service.ts
+++ b/src/app/services/play-list.service.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@angular/core';
+import { AngularFirestore } from '@angular/fire/firestore';
+import { AuthService } from './auth.service';
+import { PlayList } from 'functions/src/intarfaces/play-list';
+import { firestore } from 'firebase';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class PlayListService {
+  constructor(private db: AngularFirestore, private authService: AuthService) {}
+
+  createPlayList(
+    playList: Omit<PlayList, 'id' | 'createdAt' | 'updateAt'>
+  ): Promise<void> {
+    const id = this.db.createId();
+    const value: PlayList = {
+      ...playList,
+      id,
+      createdAt: firestore.Timestamp.now(),
+      updateAt: firestore.Timestamp.now(),
+    };
+    return this.db
+      .doc<PlayList>(`users/${playList.creatorId}/playList/${id}`)
+      .set(value);
+  }
+}

--- a/src/app/shared/angular-material.module.ts
+++ b/src/app/shared/angular-material.module.ts
@@ -3,12 +3,14 @@ import { NgModule } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
+import { MatDialogModule } from '@angular/material/dialog';
 
 const materialModules = [
   MatIconModule,
   MatFormFieldModule,
   MatButtonModule,
   CommonModule,
+  MatDialogModule,
 ];
 
 @NgModule({


### PR DESCRIPTION
fix #21 
マイリスト作成で、Firestoreにデータを追加する実装をしました！
作業内容は以下の通りになります。ご確認よろしくお願い致します！
## 実装内容

- create-listコンポーネント(ダイアログ)の作成
- ヘッダーにダイアログを開くボタンの設置
- マイリスト作成でFirestoreのuserにサブコレクションplayList/idのドキュメントを追加する機能
- mat-input、mat-selectにValidatorの実装
- input内にclearボタン設置

## image
[![Image from Gyazo](https://i.gyazo.com/27b9f2d265689adc01b04a5360dd565e.gif)](https://gyazo.com/27b9f2d265689adc01b04a5360dd565e)