### PR TITLE
Feature/14 リスト画面の実装

### DIFF
--- a/src/app/create-list/create-list.component.html
+++ b/src/app/create-list/create-list.component.html
@@ -2,11 +2,10 @@
   <h1 class="create-list__title" matDialogTitle>マイリスト作成</h1>
 
   <mat-dialog-content>
-    <form [formGroup]="form">
+    <form (keydown.enter)="$event.preventDefault()" [formGroup]="form">
       <mat-form-field class="create-list__input" appearance="outline">
         <mat-label>名前</mat-label>
         <input
-          (keydown.enter)="(false)"
           formControlName="listName"
           matInput
           placeholder="マイリストの名前を入力"

--- a/src/app/create-list/create-list.component.html
+++ b/src/app/create-list/create-list.component.html
@@ -6,6 +6,7 @@
       <mat-form-field class="create-list__input" appearance="outline">
         <mat-label>名前</mat-label>
         <input
+          (keydown.enter)="(false)"
           formControlName="listName"
           matInput
           placeholder="マイリストの名前を入力"

--- a/src/app/home/home.module.ts
+++ b/src/app/home/home.module.ts
@@ -3,9 +3,22 @@ import { CommonModule } from '@angular/common';
 
 import { HomeRoutingModule } from './home-routing.module';
 import { HomeComponent } from './home/home.component';
+import { PlayListComponent } from '../play-list/play-list.component';
+
+import { AngularMaterialModule } from '../shared/angular-material.module';
+import { MatCardModule } from '@angular/material/card';
+import { MatDividerModule } from '@angular/material/divider';
+import { MatMenuModule } from '@angular/material/menu';
 
 @NgModule({
-  declarations: [HomeComponent],
-  imports: [CommonModule, HomeRoutingModule],
+  declarations: [HomeComponent, PlayListComponent],
+  imports: [
+    CommonModule,
+    HomeRoutingModule,
+    AngularMaterialModule,
+    MatCardModule,
+    MatDividerModule,
+    MatMenuModule,
+  ],
 })
 export class HomeModule {}

--- a/src/app/home/home/home.component.html
+++ b/src/app/home/home/home.component.html
@@ -1,1 +1,1 @@
-<p>home works!</p>
+<app-play-list></app-play-list>

--- a/src/app/play-list/play-list.component.html
+++ b/src/app/play-list/play-list.component.html
@@ -1,0 +1,47 @@
+<div class="grid">
+  <ng-container *ngIf="user$ | async as user">
+    <div class="card" *ngFor="let playList of playLists$ | async">
+      <a class="card__link" href="">
+        <div
+          class="card__thumbnail"
+          style="background-image: url(http://placehold.jp/1000x1000.png);"
+        ></div>
+        <div class="card__contents">
+          <div
+            class="card__avatar"
+            [style.background-image]="'url(' + user.avatarURL + ')'"
+          ></div>
+          <div class="card__items">
+            <h3 class="card__title">
+              {{ playList.listName }}
+            </h3>
+            <p class="card__sub-title">{{ user.name }}</p>
+            <p class="card__date">
+              {{ playList.createdAt.toDate() | date: 'yyyy年MM月dd日' }}
+            </p>
+          </div>
+        </div>
+      </a>
+      <mat-divider></mat-divider>
+      <div class="card__option" align="end">
+        <button
+          class="card__option-button"
+          [matMenuTriggerFor]="menu"
+          mat-icon-button
+        >
+          <mat-icon>more_horiz</mat-icon>
+        </button>
+        <mat-menu #menu="matMenu">
+          <button mat-menu-item>
+            <mat-icon>settings</mat-icon>
+            <span>編集</span>
+          </button>
+          <button mat-menu-item>
+            <mat-icon>delete</mat-icon>
+            <span>削除</span>
+          </button>
+        </mat-menu>
+      </div>
+    </div>
+  </ng-container>
+</div>

--- a/src/app/play-list/play-list.component.scss
+++ b/src/app/play-list/play-list.component.scss
@@ -1,0 +1,80 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr 1fr;
+  gap: 16px;
+}
+
+.card {
+  background-color: transparent;
+  box-shadow: none;
+  padding: 0;
+  position: relative;
+  margin-top: 40px;
+  &__link {
+    text-decoration: none;
+  }
+  &__thumbnail {
+    padding-bottom: 56.25%;
+    background: center / cover;
+    margin-bottom: 16px;
+  }
+  &__avatar {
+    border-radius: 50%;
+    width: 40px;
+    height: 40px;
+    background: center / cover;
+    margin-right: 8px;
+  }
+  &__contents {
+    display: flex;
+    height: 120px;
+  }
+  &__items {
+    flex: 1;
+    margin-right: 16px;
+  }
+  &__title {
+    font-size: 16px;
+    font-weight: bold;
+    line-height: 26px;
+    color: white;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    overflow: hidden;
+    margin-bottom: 8px;
+    word-break: break-word;
+  }
+  &__sub-title {
+    font-size: 12px;
+    color: rgba(255, 255, 255, 0.7);
+  }
+  &__date {
+    font-size: 12px;
+    color: rgba(255, 255, 255, 0.7);
+  }
+  &__option-button {
+    position: absolute;
+    visibility: hidden;
+    margin-bottom: 2px;
+    opacity: 0;
+    z-index: 1;
+    bottom: 0;
+    right: 0;
+    transition: linear 0.1s;
+  }
+  .card:hover &__option-button {
+    visibility: visible;
+    opacity: 1;
+    position: absolute;
+    z-index: 1;
+    transition: linear 0.1s;
+  }
+}

--- a/src/app/play-list/play-list.component.spec.ts
+++ b/src/app/play-list/play-list.component.spec.ts
@@ -1,0 +1,24 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PlayListComponent } from './play-list.component';
+
+describe('PlayListComponent', () => {
+  let component: PlayListComponent;
+  let fixture: ComponentFixture<PlayListComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [PlayListComponent],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(PlayListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/play-list/play-list.component.ts
+++ b/src/app/play-list/play-list.component.ts
@@ -1,0 +1,25 @@
+import { Component, OnInit } from '@angular/core';
+import { PlayList } from 'functions/src/intarfaces/play-list';
+import { Observable } from 'rxjs';
+import { PlayListService } from '../services/play-list.service';
+import { AuthService } from '../services/auth.service';
+import { switchMap } from 'rxjs/operators';
+
+@Component({
+  selector: 'app-play-list',
+  templateUrl: './play-list.component.html',
+  styleUrls: ['./play-list.component.scss'],
+})
+export class PlayListComponent implements OnInit {
+  user$ = this.authService.user$;
+  playLists$: Observable<PlayList[]> = this.user$.pipe(
+    switchMap((user) => this.playListService.getPlayLists(user.uid))
+  );
+
+  constructor(
+    private playListService: PlayListService,
+    private authService: AuthService
+  ) {}
+
+  ngOnInit(): void {}
+}

--- a/src/app/services/play-list.service.ts
+++ b/src/app/services/play-list.service.ts
@@ -3,6 +3,7 @@ import { AngularFirestore } from '@angular/fire/firestore';
 import { AuthService } from './auth.service';
 import { PlayList } from 'functions/src/intarfaces/play-list';
 import { firestore } from 'firebase';
+import { Observable } from 'rxjs';
 
 @Injectable({
   providedIn: 'root',
@@ -21,7 +22,13 @@ export class PlayListService {
       updateAt: firestore.Timestamp.now(),
     };
     return this.db
-      .doc<PlayList>(`users/${playList.creatorId}/playList/${id}`)
+      .doc<PlayList>(`users/${this.authService.uid}/playLists/${id}`)
       .set(value);
+  }
+
+  getPlayLists(uid: string): Observable<PlayList[]> {
+    return this.db
+      .collection<PlayList>(`users/${uid}/playLists`)
+      .valueChanges();
   }
 }


### PR DESCRIPTION
fix #14 
作成したマイリストをFirestoreから取得、表示する実装をしました！
作業内容は以下の通りになります。ご確認よろしくお願い致します！
## 実装内容

- Firestoreからマイリスト名、ユーザーネーム、ユーザーのアバター画像、作成した日付を取得して表示
- マイリストを作成したらリストに表示される、コンポーネントの実装
- カードをホバーした際にメニューボタンが表示される
- メニューボタンクリックで『削除』『編集』メニューの表示(機能は後に実装予定)
- サムネイル画像はダミー

## image
[![Image from Gyazo](https://i.gyazo.com/24e7435d8856109ffab1e2eada92ef98.gif)](https://gyazo.com/24e7435d8856109ffab1e2eada92ef98)