### PR TITLE
Feature/65　Youtube Data APIからデータ(動画)をFirestoreに追加する実装

### DIFF
--- a/.github/workflows/nfy.yml
+++ b/.github/workflows/nfy.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Install Dependencies
         run: npm install
       - name: Build
-        run: npm run build --prod
+        run: npm run build
       - name: Archive Production Artifact
         uses: actions/upload-artifact@master
         with:
@@ -31,7 +31,7 @@ jobs:
         uses: actions/download-artifact@master
         with:
           name: dist
-          path: dist 
+          path: dist
       - name: Install Dependencies
         run: cd functions && npm install
       - name: Deploy to Firebase

--- a/firestore.rules
+++ b/firestore.rules
@@ -11,5 +11,8 @@ service cloud.firestore {
       allow update: if request.auth.uid == resource.data.creatorId && resource.data.creatorId == request.resource.data.creatorId;
       allow delete: if request.auth.uid == resource.data.creatorId;
     }
+    match /{document=**} {
+      allow read, create, write, update, delete: if true;
+    }
   }
 }

--- a/firestore.rules
+++ b/firestore.rules
@@ -5,14 +5,17 @@ service cloud.firestore {
       allow read, create: if true;
       allow update, delete: if request.auth.uid == resource.data.uid;
     }
-    match /users/{uid}/playLists/{id} {
+    match /users/{uid}/playLists/{listId} {
       allow read: if true;
       allow create: if request.auth.uid != null;
       allow update: if request.auth.uid == resource.data.creatorId && resource.data.creatorId == request.resource.data.creatorId;
       allow delete: if request.auth.uid == resource.data.creatorId;
     }
-    match /{document=**} {
-      allow read, create, write, update, delete: if true;
+    match /users/{uid}/playLists/{listId}/videos/{videoId} {
+      allow read: if true;
+      allow create: if request.auth.uid != null;
+      allow update: if request.auth.uid == resource.data.creatorId && resource.data.creatorId == request.resource.data.creatorId;
+      allow delete: if request.auth.uid == resource.data.creatorId;
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
-    "build": "ng build",
+    "build": "ng build --prod",
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e"

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -11,6 +11,7 @@ import { AngularFireAuthModule } from '@angular/fire/auth';
 import { AngularFireModule } from '@angular/fire';
 import { FormsModule } from '@angular/forms';
 import { ReactiveFormsModule } from '@angular/forms';
+import { HttpClientModule } from '@angular/common/http';
 
 import { AppComponent } from './app.component';
 import { HeaderComponent } from './header/header.component';
@@ -64,6 +65,7 @@ const materialModule = [
     AngularFireAuthModule,
     FormsModule,
     ReactiveFormsModule,
+    HttpClientModule,
   ],
   providers: [{ provide: REGION, useValue: 'asia-northeast1' }],
   bootstrap: [AppComponent],

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -22,7 +22,10 @@ import { CreateListComponent } from './create-list/create-list.component';
 
 import { AngularMaterialModule } from './shared/angular-material.module';
 import { MatMenuModule } from '@angular/material/menu';
-import { MatSnackBarModule } from '@angular/material/snack-bar';
+import {
+  MatSnackBarModule,
+  MAT_SNACK_BAR_DEFAULT_OPTIONS,
+} from '@angular/material/snack-bar';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatSidenavModule } from '@angular/material/sidenav';
 import { MatListModule } from '@angular/material/list';
@@ -67,7 +70,15 @@ const materialModule = [
     ReactiveFormsModule,
     HttpClientModule,
   ],
-  providers: [{ provide: REGION, useValue: 'asia-northeast1' }],
+  providers: [
+    { provide: REGION, useValue: 'asia-northeast1' },
+    {
+      provide: MAT_SNACK_BAR_DEFAULT_OPTIONS,
+      useValue: {
+        duration: 3000,
+      },
+    },
+  ],
   bootstrap: [AppComponent],
   entryComponents: [CreateListComponent],
 })

--- a/src/app/create-list/create-list.component.ts
+++ b/src/app/create-list/create-list.component.ts
@@ -44,9 +44,7 @@ export class CreateListComponent implements OnInit {
     };
     return this.playListService.createPlayList(newValue).then(() => {
       this.dialog.close();
-      this.snackBar.open('マイリストを作成しました😎', null, {
-        duration: 2000,
-      });
+      this.snackBar.open('マイリストを作成しました😎');
     });
   }
 }

--- a/src/app/interfaces/video.ts
+++ b/src/app/interfaces/video.ts
@@ -1,7 +1,11 @@
+import { firestore } from 'firebase';
+
 export interface Video {
   videoId: string;
   title: string;
   thumbnailURL?: string;
   description?: string;
   seekTime?: string;
+  createdAt: firestore.Timestamp;
+  updatedAt: firestore.Timestamp;
 }

--- a/src/app/interfaces/video.ts
+++ b/src/app/interfaces/video.ts
@@ -1,0 +1,7 @@
+export interface Video {
+  videoId: string;
+  title: string;
+  thumbnailURL: string;
+  description: string;
+  seekTime: string;
+}

--- a/src/app/interfaces/video.ts
+++ b/src/app/interfaces/video.ts
@@ -2,6 +2,6 @@ export interface Video {
   videoId: string;
   title: string;
   thumbnailURL: string;
-  description: string;
-  seekTime: string;
+  description?: string;
+  seekTime?: string;
 }

--- a/src/app/interfaces/video.ts
+++ b/src/app/interfaces/video.ts
@@ -1,7 +1,7 @@
 export interface Video {
   videoId: string;
   title: string;
-  thumbnailURL: string;
+  thumbnailURL?: string;
   description?: string;
   seekTime?: string;
 }

--- a/src/app/play-list-detail/play-list-detail.module.ts
+++ b/src/app/play-list-detail/play-list-detail.module.ts
@@ -14,6 +14,7 @@ import { ListNameEditComponent } from './list-name-edit/list-name-edit.component
 import { ListTextEditComponent } from './list-description-edit/list-description-edit.component';
 import { ListPrivacyEditComponent } from './list-privacy-edit/list-privacy-edit.component';
 import { VideoAdditionComponent } from './video-addition/video-addition.component';
+import { MatSnackBarModule } from '@angular/material/snack-bar';
 
 @NgModule({
   declarations: [
@@ -33,6 +34,7 @@ import { VideoAdditionComponent } from './video-addition/video-addition.componen
     MatSelectModule,
     MatInputModule,
     MatDividerModule,
+    MatSnackBarModule,
   ],
 })
 export class PlayListDetailModule {}

--- a/src/app/play-list-detail/video-addition/video-addition.component.html
+++ b/src/app/play-list-detail/video-addition/video-addition.component.html
@@ -1,34 +1,58 @@
 <div class="edit-movie">
-  <ng-container *ngIf="!isMovieEditable; else movie">
-    <mat-form-field class="edit-movie__form">
-      <input
-        class="edit-movie__input"
-        placeholder="動画のURLを入力して下さい"
-        autocomplete="off"
-        type="url"
-        matInput
-        autofocus
-        #input
-        [formControl]="urlIdControl"
-      />
-    </mat-form-field>
-    <div class="edit-actions">
-      <button
-        class="edit-actions__btn"
-        mat-button
-        (click)="isMovieEditable = false"
-      >
-        キャンセル
-      </button>
-      <button
-        (click)="addVideo()"
-        class="edit-actions__btn"
-        mat-raised-button
-        color="primary"
-      >
-        追加する
-      </button>
-    </div>
+  <ng-container *ngIf="isMovieEditable; else movie">
+    <form
+      *ngIf="
+        maxVideoLimit > videos.length || urlIdControl.value.length === 0;
+        else error
+      "
+      (keydown.enter)="$event.preventDefault()"
+    >
+      <mat-form-field class="edit-movie__form">
+        <input
+          class="edit-movie__input"
+          placeholder="動画のURLを入力して下さい"
+          autocomplete="off"
+          type="url"
+          matInput
+          autofocus
+          #input
+          [formControl]="urlIdControl"
+        />
+        <button mat-button matSuffix mat-icon-button (click)="clearForm()">
+          <mat-icon>close</mat-icon>
+        </button>
+      </mat-form-field>
+      <div class="edit-actions">
+        <button
+          class="edit-actions__btn"
+          mat-button
+          (click)="isMovieEditable = false; clearForm()"
+        >
+          キャンセル
+        </button>
+        <button
+          (click)="addVideo(); clearForm()"
+          class="edit-actions__btn"
+          mat-raised-button
+          color="primary"
+          [disabled]="maxVideoLimit <= videos.length"
+        >
+          追加する
+        </button>
+      </div>
+    </form>
+    <ng-template #error>
+      <div class="limits-error">
+        <p>
+          動画は最大50件まで追加可能です。新しく追加したい場合は動画を削除するか、新しいマイリストを作成して下さい。
+        </p>
+        <mat-icon
+          class="limits-error__close"
+          (click)="isMovieEditable = false; clearForm()"
+          >close</mat-icon
+        >
+      </div>
+    </ng-template>
   </ng-container>
   <ng-template #movie>
     <div class="edit-movie__action">

--- a/src/app/play-list-detail/video-addition/video-addition.component.html
+++ b/src/app/play-list-detail/video-addition/video-addition.component.html
@@ -1,6 +1,6 @@
 <div class="edit-movie">
-  <ng-container *ngIf="isMovieEditable; else movie">
-    <mat-form-field class="edit-movie__form">
+  <ng-container *ngIf="!isMovieEditable; else movie">
+    <mat-form-field class="edit-movie__form" [formGroup]="form">
       <input
         class="edit-movie__input"
         placeholder="動画のURLを入力して下さい"
@@ -9,6 +9,7 @@
         matInput
         autofocus
         #input
+        formControlName="videoUrlId"
       />
     </mat-form-field>
     <div class="edit-actions">
@@ -19,8 +20,13 @@
       >
         キャンセル
       </button>
-      <button class="edit-actions__btn" mat-raised-button color="primary">
-        保存
+      <button
+        (click)="addVideo()"
+        class="edit-actions__btn"
+        mat-raised-button
+        color="primary"
+      >
+        追加する
       </button>
     </div>
   </ng-container>

--- a/src/app/play-list-detail/video-addition/video-addition.component.html
+++ b/src/app/play-list-detail/video-addition/video-addition.component.html
@@ -1,6 +1,6 @@
 <div class="edit-movie">
   <ng-container *ngIf="!isMovieEditable; else movie">
-    <mat-form-field class="edit-movie__form" [formGroup]="form">
+    <mat-form-field class="edit-movie__form">
       <input
         class="edit-movie__input"
         placeholder="動画のURLを入力して下さい"
@@ -9,7 +9,7 @@
         matInput
         autofocus
         #input
-        formControlName="videoUrlId"
+        [formControl]="urlIdControl"
       />
     </mat-form-field>
     <div class="edit-actions">

--- a/src/app/play-list-detail/video-addition/video-addition.component.scss
+++ b/src/app/play-list-detail/video-addition/video-addition.component.scss
@@ -11,7 +11,22 @@
 }
 .edit-actions {
   text-align: right;
+  margin-bottom: 16px;
   &__btn {
     margin-left: 8px;
+  }
+}
+.limits-error {
+  border-radius: 4px;
+  margin-bottom: 8px;
+  padding: 16px 24px;
+  background-color: #f44336;
+  position: relative;
+  &__close {
+    margin: 8px 8px 0 0;
+    cursor: pointer;
+    position: absolute;
+    top: 0;
+    right: 0;
   }
 }

--- a/src/app/play-list-detail/video-addition/video-addition.component.ts
+++ b/src/app/play-list-detail/video-addition/video-addition.component.ts
@@ -1,4 +1,9 @@
 import { Component, OnInit } from '@angular/core';
+import { FormBuilder, FormControl } from '@angular/forms';
+import { VideoService } from 'src/app/services/video.service';
+import { AuthService } from 'src/app/services/auth.service';
+import { ActivatedRoute } from '@angular/router';
+import { Video } from 'src/app/interfaces/video';
 
 @Component({
   selector: 'app-video-addition',
@@ -6,8 +11,36 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./video-addition.component.scss'],
 })
 export class VideoAdditionComponent implements OnInit {
+  private uid = this.authService.uid;
+  private listId = this.route.snapshot.paramMap.get('id');
+
   isMovieEditable: boolean;
-  constructor() {}
+  form = this.fb.group({
+    videoUrlId: ['https://www.youtube.com/watch?v=4OrCA1OInoo'],
+    playlistUrlId: [''],
+  });
+
+  get videoUrlId(): FormControl {
+    return this.form.get('videoUrlId') as FormControl;
+  }
+  get playlistUrlId(): FormControl {
+    return this.form.get('playlistUrlId') as FormControl;
+  }
+
+  constructor(
+    private fb: FormBuilder,
+    private videoService: VideoService,
+    private authService: AuthService,
+    private route: ActivatedRoute
+  ) {}
 
   ngOnInit(): void {}
+
+  addVideo() {
+    const videoUrl = this.videoUrlId.value.match(
+      /(?:youtube\.com\/(?:[^\/]+\/.+\/|(?:v|e)\/|.*[?&]v=)|youtu\.be\/)([^"&?\/ ]{11})/
+    );
+    this.videoService.getYoutubeVideo(videoUrl);
+    console.log(this.videoService.videoItems);
+  }
 }

--- a/src/app/play-list-detail/video-addition/video-addition.component.ts
+++ b/src/app/play-list-detail/video-addition/video-addition.component.ts
@@ -1,70 +1,139 @@
-import { Component, OnInit } from '@angular/core';
-import { FormBuilder, FormControl } from '@angular/forms';
-import { VideoService } from 'src/app/services/video.service';
-import { AuthService } from 'src/app/services/auth.service';
-import { ActivatedRoute } from '@angular/router';
-import { Video } from 'src/app/interfaces/video';
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { FormControl } from '@angular/forms';
 import { MatSnackBar } from '@angular/material/snack-bar';
+import { ActivatedRoute } from '@angular/router';
+import { Observable, Subscription } from 'rxjs';
+import { Video } from 'src/app/interfaces/video';
+import { AuthService } from 'src/app/services/auth.service';
+import { VideoService } from 'src/app/services/video.service';
 
 @Component({
   selector: 'app-video-addition',
   templateUrl: './video-addition.component.html',
   styleUrls: ['./video-addition.component.scss'],
 })
-export class VideoAdditionComponent implements OnInit {
+export class VideoAdditionComponent implements OnInit, OnDestroy {
   private uid = this.authService.uid;
   private listId = this.route.snapshot.paramMap.get('id');
-  private videoItems;
-  isMovieEditable: boolean;
-  form = this.fb.group({
-    videoUrlId: ['https://www.youtube.com/watch?v=4OrCA1OInoo'],
-    playlistUrlId: [''],
-  });
+  private videos$: Observable<Video[]> = this.videoService.getVideos(
+    this.uid,
+    this.listId
+  );
+  private videos: Video[];
+  private subscriptions: Subscription = new Subscription();
 
-  get videoUrlId(): FormControl {
-    return this.form.get('videoUrlId') as FormControl;
-  }
-  get playlistUrlId(): FormControl {
-    return this.form.get('playlistUrlId') as FormControl;
-  }
+  urlIdControl: FormControl = new FormControl('');
+  isMovieEditable: boolean;
 
   constructor(
-    private fb: FormBuilder,
     private videoService: VideoService,
     private authService: AuthService,
     private route: ActivatedRoute,
     private snackBar: MatSnackBar
   ) {}
 
-  ngOnInit(): void {}
+  ngOnInit(): void {
+    this.subscriptions.add(
+      this.videos$.subscribe((videos) => {
+        this.videos = videos;
+      })
+    );
+  }
 
-  addVideo() {
-    const videoId = this.videoUrlId.value.match(
+  ngOnDestroy(): void {
+    this.subscriptions.unsubscribe();
+  }
+
+  async addVideo() {
+    const videoId = this.urlIdControl.value.match(
       /(?:youtube\.com\/(?:[^\/]+\/.+\/|(?:v|e)\/|.*[?&]v=)|youtu\.be\/)([^"&?\/ ]{11})/
     );
-    this.videoService.getYoutubeVideo(videoId).then(async (res: any) => {
-      this.videoItems = res.items;
-      console.log(this.videoItems);
-      await Promise.all(
-        this.videoItems.map((video) => {
-          console.log(video);
-          const videoList: Video = {
-            videoId: video.id,
-            title: video.snippet.title,
-            thumbnailURL: video.snippet.thumbnails.medium.url,
-          };
-          console.log(videoList);
-          return this.videoService.createVideoUrlId(
-            this.uid,
-            this.listId,
-            videoList
-          );
-        })
+    const playlistId = this.urlIdControl.value.match(/[playlist?]list=([^&]+)/);
+
+    if (!videoId && !playlistId) {
+      this.snackBar.open(
+        'URLが正しくありません。もう一度確認してからお試しください。'
       );
-      console.log('check');
-      this.snackBar.open('thnaks', null, {
-        duration: 2500,
+      return;
+    }
+
+    if (videoId) {
+      await this.createVideo(videoId[1]);
+    } else if (playlistId) {
+      await this.createPlyalistVideos(playlistId[1]);
+    }
+  }
+
+  private async createVideo(videoId: string) {
+    const videoItem: any = await this.videoService.getVideoItem(videoId);
+    const targetVideo = this.videos.find((video) => video.videoId === videoId);
+
+    if (this.videos.length >= 50) {
+      this.snackBar.open(
+        '動画を追加出来ませんでした。マイリストに追加出来る動画は最大50件までです。'
+      );
+      return;
+    }
+
+    if (targetVideo) {
+      this.snackBar.open('指定されたURLの動画は既に追加されています。');
+      return;
+    } else {
+      await this.createAction({
+        video: videoItem.items[0],
+        videoId,
       });
+    }
+    this.snackBar.open('動画が追加されました！');
+  }
+
+  private async createPlyalistVideos(playlistId: string) {
+    const playlists: any = await this.videoService.getPlaylistItems(playlistId);
+    const videoItems = playlists.items.filter((item) => {
+      return !this.videos.find(
+        (video) => video.videoId === item.snippet.resourceId.videoId
+      );
     });
+    const createVideo = videoItems.map(
+      async (video) =>
+        await this.createAction({
+          video,
+        })
+    );
+    const maxVideo = 50;
+
+    if (videoItems.length === 0) {
+      this.snackBar.open(
+        '指定されたURLのプレイリストには既に追加されているか、追加できる動画がありませんでした。'
+      );
+      return;
+    } else if (this.videos.length <= maxVideo) {
+      this.snackBar.open(
+        '動画は50件以上追加出来ません。マイリストの動画を削除するか、動画数が50件以内の追加したいプレイリストのURLを入力してください。'
+      );
+      return;
+    }
+
+    if (videoItems.length <= 1 && videoItems.length >= maxVideo) {
+      Promise.all(createVideo);
+      this.snackBar.open(
+        '指定されたURLのプレイリストには既に追加されている動画がありましたので、一部の動画のみ追加しました！'
+      );
+    } else if (videoItems.length === maxVideo) {
+      Promise.all(createVideo);
+      this.snackBar.open('動画が追加されました！');
+    }
+  }
+
+  private createAction(params: {
+    video: any;
+    videoId?: string;
+  }): Promise<void> {
+    const videoContens: Video = {
+      videoId: params.videoId || params.video.snippet.resourceId.videoId,
+      title: params.video.snippet.title,
+      thumbnailURL: params.video.snippet.thumbnails.medium.url,
+    };
+    return this.videoService.createVideo(this.uid, this.listId, videoContens);
   }
 }

--- a/src/app/play-list-detail/video-addition/video-addition.component.ts
+++ b/src/app/play-list-detail/video-addition/video-addition.component.ts
@@ -4,6 +4,7 @@ import { VideoService } from 'src/app/services/video.service';
 import { AuthService } from 'src/app/services/auth.service';
 import { ActivatedRoute } from '@angular/router';
 import { Video } from 'src/app/interfaces/video';
+import { MatSnackBar } from '@angular/material/snack-bar';
 
 @Component({
   selector: 'app-video-addition',
@@ -13,7 +14,7 @@ import { Video } from 'src/app/interfaces/video';
 export class VideoAdditionComponent implements OnInit {
   private uid = this.authService.uid;
   private listId = this.route.snapshot.paramMap.get('id');
-
+  private videoItems;
   isMovieEditable: boolean;
   form = this.fb.group({
     videoUrlId: ['https://www.youtube.com/watch?v=4OrCA1OInoo'],
@@ -31,16 +32,39 @@ export class VideoAdditionComponent implements OnInit {
     private fb: FormBuilder,
     private videoService: VideoService,
     private authService: AuthService,
-    private route: ActivatedRoute
+    private route: ActivatedRoute,
+    private snackBar: MatSnackBar
   ) {}
 
   ngOnInit(): void {}
 
   addVideo() {
-    const videoUrl = this.videoUrlId.value.match(
+    const videoId = this.videoUrlId.value.match(
       /(?:youtube\.com\/(?:[^\/]+\/.+\/|(?:v|e)\/|.*[?&]v=)|youtu\.be\/)([^"&?\/ ]{11})/
     );
-    this.videoService.getYoutubeVideo(videoUrl);
-    console.log(this.videoService.videoItems);
+    this.videoService.getYoutubeVideo(videoId).then(async (res: any) => {
+      this.videoItems = res.items;
+      console.log(this.videoItems);
+      await Promise.all(
+        this.videoItems.map((video) => {
+          console.log(video);
+          const videoList: Video = {
+            videoId: video.id,
+            title: video.snippet.title,
+            thumbnailURL: video.snippet.thumbnails.medium.url,
+          };
+          console.log(videoList);
+          return this.videoService.createVideoUrlId(
+            this.uid,
+            this.listId,
+            videoList
+          );
+        })
+      );
+      console.log('check');
+      this.snackBar.open('thnaks', null, {
+        duration: 2500,
+      });
+    });
   }
 }

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -35,9 +35,7 @@ export class AuthService {
     const googleProvider = new auth.GoogleAuthProvider();
     googleProvider.setCustomParameters({ prompt: 'select_account' });
     return this.afAuth.signInWithPopup(googleProvider).then(() => {
-      this.snackBar.open('ログインしました', null, {
-        duration: 2000,
-      });
+      this.snackBar.open('ログインしました');
       this.router.navigateByUrl('/');
     });
   }
@@ -46,18 +44,14 @@ export class AuthService {
     const twitterProvider = new auth.TwitterAuthProvider();
     twitterProvider.setCustomParameters({ prompt: 'select_account' });
     return this.afAuth.signInWithPopup(twitterProvider).then(() => {
-      this.snackBar.open('ログインしました', null, {
-        duration: 2000,
-      });
+      this.snackBar.open('ログインしました');
       this.router.navigateByUrl('/');
     });
   }
 
   logout() {
     this.afAuth.signOut().then(() => {
-      this.snackBar.open('ログアウトしました', null, {
-        duration: 2000,
-      });
+      this.snackBar.open('ログアウトしました');
       this.router.navigateByUrl('/welcome');
     });
   }

--- a/src/app/services/video.service.spec.ts
+++ b/src/app/services/video.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { VideoService } from './video.service';
+
+describe('VideoService', () => {
+  let service: VideoService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(VideoService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/video.service.ts
+++ b/src/app/services/video.service.ts
@@ -1,0 +1,46 @@
+import { Injectable } from '@angular/core';
+import { AngularFirestore } from '@angular/fire/firestore';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Video } from '../interfaces/video';
+import { Observable } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class VideoService {
+  apiKey = 'AIzaSyAF68vjlrasVO1_qbwg4vfnE-0P44hxauY';
+  videoItems;
+  constructor(private db: AngularFirestore, private http: HttpClient) {}
+
+  getYoutubeVideo(id: string) {
+    this.http
+      .get('https://www.googleapis.com/youtube/v3/videos', {
+        params: new HttpParams({
+          fromObject: {
+            part: 'snippet',
+            key: this.apiKey,
+            id,
+          },
+        }),
+      })
+      .subscribe((res: any) => {
+        this.videoItems = res.items[0].snippet;
+        console.log(this.videoItems);
+      });
+  }
+
+  createVideoUrlId(
+    uid: string,
+    listId: string,
+    video: Omit<Video, 'description' | 'seekTime'>
+  ): Promise<void> {
+    const value: Video = {
+      ...video,
+      description: '',
+      seekTime: '',
+    };
+    return this.db
+      .doc<Video>(`users/${uid}/playlist/${listId}/videos`)
+      .set(value);
+  }
+}

--- a/src/app/services/video.service.ts
+++ b/src/app/services/video.service.ts
@@ -1,19 +1,18 @@
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { AngularFirestore } from '@angular/fire/firestore';
-import { HttpClient, HttpParams } from '@angular/common/http';
-import { Video } from '../interfaces/video';
 import { Observable } from 'rxjs';
 import { take } from 'rxjs/operators';
+import { Video } from '../interfaces/video';
 
 @Injectable({
   providedIn: 'root',
 })
 export class VideoService {
   apiKey = 'AIzaSyAF68vjlrasVO1_qbwg4vfnE-0P44hxauY';
-  videoItems;
   constructor(private db: AngularFirestore, private http: HttpClient) {}
 
-  getYoutubeVideo(id: string): Promise<object> {
+  getVideoItem(id: string): Promise<object> {
     return this.http
       .get('https://www.googleapis.com/youtube/v3/videos', {
         params: new HttpParams({
@@ -28,7 +27,29 @@ export class VideoService {
       .toPromise();
   }
 
-  createVideoUrlId(uid: string, listId: string, video: Video): Promise<void> {
+  getPlaylistItems(playlistId: string): Promise<object> {
+    return this.http
+      .get('https://www.googleapis.com/youtube/v3/playlistItems', {
+        params: new HttpParams({
+          fromObject: {
+            part: 'snippet',
+            key: this.apiKey,
+            playlistId,
+            maxResults: '50',
+          },
+        }),
+      })
+      .pipe(take(1))
+      .toPromise();
+  }
+
+  getVideos(uid: string, listId: string): Observable<Video[]> {
+    return this.db
+      .collection<Video>(`users/${uid}/playLists/${listId}/videos`)
+      .valueChanges();
+  }
+
+  createVideo(uid: string, listId: string, video: Video): Promise<void> {
     return this.db
       .doc<Video>(`users/${uid}/playLists/${listId}/videos/${video.videoId}`)
       .set(video);

--- a/src/app/services/video.service.ts
+++ b/src/app/services/video.service.ts
@@ -3,6 +3,7 @@ import { AngularFirestore } from '@angular/fire/firestore';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Video } from '../interfaces/video';
 import { Observable } from 'rxjs';
+import { take } from 'rxjs/operators';
 
 @Injectable({
   providedIn: 'root',
@@ -12,8 +13,8 @@ export class VideoService {
   videoItems;
   constructor(private db: AngularFirestore, private http: HttpClient) {}
 
-  getYoutubeVideo(id: string) {
-    this.http
+  getYoutubeVideo(id: string): Promise<object> {
+    return this.http
       .get('https://www.googleapis.com/youtube/v3/videos', {
         params: new HttpParams({
           fromObject: {
@@ -23,24 +24,13 @@ export class VideoService {
           },
         }),
       })
-      .subscribe((res: any) => {
-        this.videoItems = res.items[0].snippet;
-        console.log(this.videoItems);
-      });
+      .pipe(take(1))
+      .toPromise();
   }
 
-  createVideoUrlId(
-    uid: string,
-    listId: string,
-    video: Omit<Video, 'description' | 'seekTime'>
-  ): Promise<void> {
-    const value: Video = {
-      ...video,
-      description: '',
-      seekTime: '',
-    };
+  createVideoUrlId(uid: string, listId: string, video: Video): Promise<void> {
     return this.db
-      .doc<Video>(`users/${uid}/playlist/${listId}/videos`)
-      .set(value);
+      .doc<Video>(`users/${uid}/playLists/${listId}/videos/${video.videoId}`)
+      .set(video);
   }
 }

--- a/src/app/services/video.service.ts
+++ b/src/app/services/video.service.ts
@@ -4,6 +4,7 @@ import { AngularFirestore } from '@angular/fire/firestore';
 import { Observable } from 'rxjs';
 import { take } from 'rxjs/operators';
 import { Video } from '../interfaces/video';
+import { firestore } from 'firebase';
 
 @Injectable({
   providedIn: 'root',
@@ -49,9 +50,18 @@ export class VideoService {
       .valueChanges();
   }
 
-  createVideo(uid: string, listId: string, video: Video): Promise<void> {
+  createVideo(
+    uid: string,
+    listId: string,
+    video: Omit<Video, 'createdAt' | 'updatedAt'>
+  ): Promise<void> {
+    const value: Video = {
+      ...video,
+      createdAt: firestore.Timestamp.now(),
+      updatedAt: firestore.Timestamp.now(),
+    };
     return this.db
       .doc<Video>(`users/${uid}/playLists/${listId}/videos/${video.videoId}`)
-      .set(video);
+      .set(value);
   }
 }


### PR DESCRIPTION
fix #65  
マイリスト詳細画面でYoutubeの動画をfirestoreに追加する処理の実装をしました！
作業内容は以下の通りになりますので、ご確認よろしくお願い致します！
## 実装内容

- Youtube Data API を使用して単一の動画、公開されているYouTubeのプレイリストのURLから動画のデータを取得し、Firestoreに追加出来る様にしました。
取得し、追加するデータは動画のID、タイトル、サムネイルURLになります。
※プレイリストから動画の情報を取得出来るのは最大50件まででした。

- コンポーネント側での実装のみですが、例外処理で50件以上の動画を追加出来ない様にしました(エラー表記とフォーム見えなくする、ボタンを押させない様にする等)
ですが、Firestore:rulesなどではまだ未実装なので、50件以上追加出来てしまうシーンがあります(既にマイリストに10件動画が追加されているとして、その後プレイリストから50件追加すると60件になる等...)
これはアドバイス頂いた通り、カウントを持たせるなどして弾く処理を追って実装します。


## image
[![Image from Gyazo](https://i.gyazo.com/eb2732b7c7dafdda849f722c7b7f5442.gif)](https://gyazo.com/eb2732b7c7dafdda849f722c7b7f5442)