### PR TITLE
Feature/61 video-listコンポーネントの作成と動画の削除機能の実装

### DIFF
--- a/src/app/animations/animations.ts
+++ b/src/app/animations/animations.ts
@@ -4,8 +4,6 @@ import {
   style,
   transition,
   animate,
-  animateChild,
-  query,
 } from '@angular/animations';
 
 export const onDrawerChange = trigger('onDrawerChange', [
@@ -21,8 +19,8 @@ export const onDrawerChange = trigger('onDrawerChange', [
       width: '240px',
     })
   ),
-  transition('close => open', animate('200ms ease-in')),
-  transition('open => close', animate('250ms ease-out')),
+  transition('close => open', animate('100ms ease-in')),
+  transition('open => close', animate('100ms ease-out')),
 ]);
 
 export const onMainContentChange = trigger('onMainContentChange', [
@@ -38,25 +36,23 @@ export const onMainContentChange = trigger('onMainContentChange', [
       'margin-left': '240px',
     })
   ),
-  transition('close => open', animate('150ms ease-in')),
-  transition('open => close', animate('150ms ease-in')),
+  transition('close => open', animate('100ms ease-in')),
+  transition('open => close', animate('100ms ease-in')),
 ]);
 
 export const animateText = trigger('animateText', [
   state(
-    'hide',
+    'close',
     style({
       display: 'none',
       opacity: 0,
     })
   ),
   state(
-    'show',
+    'open',
     style({
       display: 'block',
       opacity: 1,
     })
   ),
-  transition('close => open', animate('100ms ease-in')),
-  transition('open => close', animate('100ms ease-out')),
 ]);

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -15,6 +15,10 @@ const routes: Routes = [
   },
   {
     path: 'play-list-detail',
+    data: {
+      isDrawerNavOpen: false,
+      isDrawerTextOpen: false,
+    },
     loadChildren: () =>
       import('src/app/play-list-detail/play-list-detail.module').then(
         (m) => m.PlayListDetailModule

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -3,24 +3,24 @@
 <mat-sidenav-container class="sidenav-container">
   <mat-sidenav
     color="basic"
-    [class.open]="!drawerService.drawerState"
-    [class.close]="drawerService.drawerState"
+    [class.open]="drawerService.isDrawerNavOpen"
+    [class.close]="!drawerService.isDrawerNavOpen"
     #sidenav
     fixedInViewport
     fixedTopGap="64"
     mode="side"
     opened
-    [@onDrawerChange]="!drawerService.drawerState ? 'open' : 'close'"
+    [@onDrawerChange]="drawerService.isDrawerNavOpen ? 'open' : 'close'"
   >
-    <app-mini-variant *ngIf="drawerService.drawerState"></app-mini-variant>
+    <app-mini-variant *ngIf="!drawerService.isDrawerNavOpen"></app-mini-variant>
     <app-drawer
-      *ngIf="!drawerService.drawerState"
-      [@animateText]="!drawerService.linkText ? 'show' : 'hide'"
+      *ngIf="drawerService.isDrawerNavOpen"
+      [@animateText]="drawerService.isDrawerTextOpen ? 'open' : 'close'"
     ></app-drawer>
   </mat-sidenav>
 
   <mat-sidenav-content
-    [@onMainContentChange]="!drawerService.drawerState ? 'open' : 'close'"
+    [@onMainContentChange]="drawerService.isDrawerNavOpen ? 'open' : 'close'"
   >
     <div class="container">
       <router-outlet></router-outlet>

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -1,12 +1,6 @@
 .mat-drawer {
   background-color: #212121;
 }
-.open {
-  width: 240px;
-}
-.close {
-  width: 72px;
-}
 
 .sidenav-container {
   height: 100%;

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { ActivatedRouteSnapshot, NavigationEnd, Router } from '@angular/router';
 import {
   animateText,
   onDrawerChange,
@@ -14,5 +15,24 @@ import { DrawerService } from './services/drawer.service';
 })
 export class AppComponent {
   title = 'note-for-youtube';
-  constructor(public drawerService: DrawerService) {}
+
+  constructor(public drawerService: DrawerService, private router: Router) {
+    this.router.events.subscribe((event) => {
+      if (event instanceof NavigationEnd) {
+        const route = this.getChildRoute(this.router.routerState.snapshot.root);
+        this.drawerService.isDrawerNavOpen =
+          route.data.isDrawerNavOpen !== false;
+        this.drawerService.isDrawerTextOpen =
+          route.data.isDrawerTextOpen !== false;
+      }
+    });
+  }
+
+  private getChildRoute(route: ActivatedRouteSnapshot) {
+    if (!route.children.length) {
+      return route;
+    } else {
+      return this.getChildRoute(route.children[0]);
+    }
+  }
 }

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -20,10 +20,10 @@ export class HeaderComponent implements OnInit {
   ngOnInit(): void {}
 
   onDrawerToggle() {
-    this.drawerService.drawerState = !this.drawerService.drawerState;
+    this.drawerService.isDrawerNavOpen = !this.drawerService.isDrawerNavOpen;
     setTimeout(() => {
-      this.drawerService.linkText = this.drawerService.drawerState;
-    }, 200);
+      this.drawerService.isDrawerTextOpen = this.drawerService.isDrawerNavOpen;
+    }, 100);
   }
 
   logout() {

--- a/src/app/interfaces/video.ts
+++ b/src/app/interfaces/video.ts
@@ -1,6 +1,7 @@
 import { firestore } from 'firebase';
 
 export interface Video {
+  creatorId: string;
   videoId: string;
   title: string;
   thumbnailURL?: string;

--- a/src/app/play-list-detail/list-name-edit/list-name-edit.component.scss
+++ b/src/app/play-list-detail/list-name-edit/list-name-edit.component.scss
@@ -4,7 +4,7 @@
   }
   &__input {
     font-size: 1.17em;
-    font-weight: bold;
+    font-weight: 500;
   }
   &__name {
     display: flex;

--- a/src/app/play-list-detail/play-list-detail-routing.module.ts
+++ b/src/app/play-list-detail/play-list-detail-routing.module.ts
@@ -4,10 +4,6 @@ import { PlayListDetailComponent } from './play-list-detail/play-list-detail.com
 
 const routes: Routes = [
   {
-    path: '',
-    component: PlayListDetailComponent,
-  },
-  {
     path: ':id',
     component: PlayListDetailComponent,
   },

--- a/src/app/play-list-detail/play-list-detail.module.ts
+++ b/src/app/play-list-detail/play-list-detail.module.ts
@@ -15,6 +15,7 @@ import { ListTextEditComponent } from './list-description-edit/list-description-
 import { ListPrivacyEditComponent } from './list-privacy-edit/list-privacy-edit.component';
 import { VideoAdditionComponent } from './video-addition/video-addition.component';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
+import { VideoListModule } from '../video-list/video-list.module';
 
 @NgModule({
   declarations: [
@@ -35,6 +36,7 @@ import { MatSnackBarModule } from '@angular/material/snack-bar';
     MatInputModule,
     MatDividerModule,
     MatSnackBarModule,
+    VideoListModule,
   ],
 })
 export class PlayListDetailModule {}

--- a/src/app/play-list-detail/play-list-detail/play-list-detail.component.html
+++ b/src/app/play-list-detail/play-list-detail/play-list-detail.component.html
@@ -1,28 +1,31 @@
 <ng-container *ngIf="playList$ | async as playList; else blank">
-  <div class="grid">
-    <div class="edit">
-      <app-list-name-edit [playList$]="playList$"></app-list-name-edit>
-      <div class="edit__stats">
-        <p>動画数 / 0</p>
-        <p>
-          ・更新日 / {{ playList.updateAt.toDate() | date: 'yyyy年MM月dd日' }}
-        </p>
+  <div class="edit">
+    <div class="edit__form-grid">
+      <div>
+        <app-list-name-edit [playList$]="playList$"></app-list-name-edit>
+        <div class="edit__stats">
+          <p>動画数 / 0</p>
+          <p>
+            ・更新日 /
+            {{ playList.updateAt.toDate() | date: 'yyyy年MM月dd日' }}
+          </p>
+        </div>
+        <app-list-privacy-edit [playList$]="playList$"></app-list-privacy-edit>
+        <app-video-addition [videos$]="videos$"></app-video-addition>
       </div>
-      <app-list-privacy-edit [playList$]="playList$"></app-list-privacy-edit>
-      <app-video-addition></app-video-addition>
+
       <app-list-description-edit
         [playList$]="playList$"
       ></app-list-description-edit>
-
-      <mat-divider></mat-divider>
     </div>
-    <div class="movies">
-      <p class="content" contenteditable>
-        Lorem ipsum dolor sit amet consectetur adipisicing elit. Omnis nulla
-        architecto maxime modi nisi. Quas saepe dolorum, architecto quia fugit
-        nulla! Natus, iure eveniet ex iusto tempora animi quibusdam porro?
-      </p>
-    </div>
+    <mat-divider></mat-divider>
+  </div>
+  <div class="movies">
+    <app-video-list
+      class="video-list-grid"
+      [listId]="listId"
+      [videos$]="videos$"
+    ></app-video-list>
   </div>
 </ng-container>
 <ng-template #blank>

--- a/src/app/play-list-detail/play-list-detail/play-list-detail.component.scss
+++ b/src/app/play-list-detail/play-list-detail/play-list-detail.component.scss
@@ -1,14 +1,12 @@
-.grid {
-  display: grid;
-  grid-template-columns: 320px 1fr;
-  gap: 24px;
-  padding: 24px 0;
-  margin: 0;
-}
-
 .edit {
+  padding: 24px 0;
   box-sizing: border-box;
   overflow: auto;
+  &__form-grid {
+    display: grid;
+    grid-template-columns: 1fr 2fr;
+    gap: 40px;
+  }
   &__stats {
     display: flex;
     align-items: center;
@@ -20,4 +18,10 @@
     display: flex;
     align-items: center;
   }
+}
+
+.video-list-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(240px, 1fr));
+  gap: 24px;
 }

--- a/src/app/play-list-detail/play-list-detail/play-list-detail.component.ts
+++ b/src/app/play-list-detail/play-list-detail/play-list-detail.component.ts
@@ -1,47 +1,39 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { PlayListService } from 'src/app/services/play-list.service';
-import { Observable } from 'rxjs';
 import { PlayList } from 'functions/src/intarfaces/play-list';
-import { switchMap, map } from 'rxjs/operators';
+import { Observable } from 'rxjs';
+import { map, switchMap } from 'rxjs/operators';
+import { Video } from 'src/app/interfaces/video';
 import { AuthService } from 'src/app/services/auth.service';
-import { DrawerService } from 'src/app/services/drawer.service';
+import { PlayListService } from 'src/app/services/play-list.service';
+import { VideoService } from 'src/app/services/video.service';
 
 @Component({
   selector: 'app-play-list-detail',
   templateUrl: './play-list-detail.component.html',
   styleUrls: ['./play-list-detail.component.scss'],
 })
-export class PlayListDetailComponent implements OnInit, OnDestroy {
-  private uid = this.authService.uid;
+export class PlayListDetailComponent implements OnInit {
   private listId$: Observable<string> = this.route.paramMap.pipe(
     map((paramMap) => paramMap.get('id'))
   );
 
+  uid = this.authService.uid;
+  listId = this.route.snapshot.paramMap.get('id');
   playList$: Observable<PlayList> = this.listId$.pipe(
     switchMap((listId) => this.playListService.getMyPlayList(this.uid, listId))
+  );
+  videos$: Observable<Video[]> = this.videoService.getVideos(
+    this.uid,
+    this.listId
   );
 
   constructor(
     private route: ActivatedRoute,
     private playListService: PlayListService,
     private authService: AuthService,
-    private drawerService: DrawerService
+    private videoService: VideoService
   ) {}
 
-  ngOnInit(): void {
-    this.drawerService.drawerState = true;
-    this.drawerAnimation();
-  }
-
-  ngOnDestroy(): void {
-    this.drawerService.drawerState = false;
-    this.drawerAnimation();
-  }
-
-  private drawerAnimation() {
-    setTimeout(() => {
-      this.drawerService.linkText = this.drawerService.drawerState;
-    }, 200);
-  }
+  ngOnInit(): void {}
 }

--- a/src/app/play-list-detail/play-list-detail/play-list-detail.component.ts
+++ b/src/app/play-list-detail/play-list-detail/play-list-detail.component.ts
@@ -1,17 +1,18 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { PlayListService } from 'src/app/services/play-list.service';
 import { Observable } from 'rxjs';
 import { PlayList } from 'functions/src/intarfaces/play-list';
 import { switchMap, map } from 'rxjs/operators';
 import { AuthService } from 'src/app/services/auth.service';
+import { DrawerService } from 'src/app/services/drawer.service';
 
 @Component({
   selector: 'app-play-list-detail',
   templateUrl: './play-list-detail.component.html',
   styleUrls: ['./play-list-detail.component.scss'],
 })
-export class PlayListDetailComponent implements OnInit {
+export class PlayListDetailComponent implements OnInit, OnDestroy {
   private uid = this.authService.uid;
   private listId$: Observable<string> = this.route.paramMap.pipe(
     map((paramMap) => paramMap.get('id'))
@@ -24,8 +25,23 @@ export class PlayListDetailComponent implements OnInit {
   constructor(
     private route: ActivatedRoute,
     private playListService: PlayListService,
-    private authService: AuthService
+    private authService: AuthService,
+    private drawerService: DrawerService
   ) {}
 
-  ngOnInit(): void {}
+  ngOnInit(): void {
+    this.drawerService.drawerState = true;
+    this.drawerAnimation();
+  }
+
+  ngOnDestroy(): void {
+    this.drawerService.drawerState = false;
+    this.drawerAnimation();
+  }
+
+  private drawerAnimation() {
+    setTimeout(() => {
+      this.drawerService.linkText = this.drawerService.drawerState;
+    }, 200);
+  }
 }

--- a/src/app/play-list-detail/video-addition/video-addition.component.ts
+++ b/src/app/play-list-detail/video-addition/video-addition.component.ts
@@ -84,6 +84,7 @@ export class VideoAdditionComponent implements OnInit, OnDestroy {
 
   private async createPlyalistVideos(playlistId: string) {
     const playlists: any = await this.videoService.getPlaylistItems(playlistId);
+    console.log(playlists);
     const videoItems = playlists.items.filter((item) => {
       return !this.videos.find(
         (video) => video.videoId === item.snippet.resourceId.videoId
@@ -125,9 +126,10 @@ export class VideoAdditionComponent implements OnInit, OnDestroy {
     videoId?: string;
   }): Promise<void> {
     const videoContens: Omit<Video, 'createdAt' | 'updatedAt'> = {
+      creatorId: this.authService.uid,
       videoId: params.videoId || params.video.snippet.resourceId.videoId,
       title: params.video.snippet.title,
-      thumbnailURL: params.video.snippet.thumbnails.medium.url,
+      thumbnailURL: params.video.snippet.thumbnails.maxres.url,
     };
     return this.videoService.createVideo(this.uid, this.listId, videoContens);
   }

--- a/src/app/play-list-detail/video-addition/video-addition.component.ts
+++ b/src/app/play-list-detail/video-addition/video-addition.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Component, Input, OnDestroy, OnInit } from '@angular/core';
 import { FormControl } from '@angular/forms';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { ActivatedRoute } from '@angular/router';
@@ -13,12 +13,9 @@ import { VideoService } from 'src/app/services/video.service';
   styleUrls: ['./video-addition.component.scss'],
 })
 export class VideoAdditionComponent implements OnInit, OnDestroy {
+  @Input() videos$: Observable<Video[]>;
   private uid = this.authService.uid;
   private listId = this.route.snapshot.paramMap.get('id');
-  private videos$: Observable<Video[]> = this.videoService.getVideos(
-    this.uid,
-    this.listId
-  );
   private subscriptions: Subscription = new Subscription();
 
   urlIdControl: FormControl = new FormControl('');
@@ -118,7 +115,7 @@ export class VideoAdditionComponent implements OnInit, OnDestroy {
     } else {
       Promise.all(createVideo);
       this.snackBar.open(
-        '既に追加されている動画がありましたので、一部の動画を追加しました！'
+        '重複する動画がありましたので、一部の動画を追加しました！'
       );
     }
   }

--- a/src/app/services/drawer.service.ts
+++ b/src/app/services/drawer.service.ts
@@ -1,11 +1,10 @@
 import { Injectable } from '@angular/core';
-import { Subject } from 'rxjs';
 
 @Injectable({
   providedIn: 'root',
 })
 export class DrawerService {
-  drawerState: boolean;
-  linkText: boolean;
+  isDrawerNavOpen = true;
+  isDrawerTextOpen = true;
   constructor() {}
 }

--- a/src/app/services/video.service.ts
+++ b/src/app/services/video.service.ts
@@ -5,13 +5,18 @@ import { Observable } from 'rxjs';
 import { take } from 'rxjs/operators';
 import { Video } from '../interfaces/video';
 import { firestore } from 'firebase';
+import { MatSnackBar } from '@angular/material/snack-bar';
 
 @Injectable({
   providedIn: 'root',
 })
 export class VideoService {
   apiKey = 'AIzaSyAF68vjlrasVO1_qbwg4vfnE-0P44hxauY';
-  constructor(private db: AngularFirestore, private http: HttpClient) {}
+  constructor(
+    private db: AngularFirestore,
+    private http: HttpClient,
+    private snackBar: MatSnackBar
+  ) {}
 
   getVideoItem(id: string): Promise<object> {
     return this.http
@@ -63,5 +68,15 @@ export class VideoService {
     return this.db
       .doc<Video>(`users/${uid}/playLists/${listId}/videos/${video.videoId}`)
       .set(value);
+  }
+
+  deleteVideo(uid: string, listId: string, videoId: string): Promise<void> {
+    console.log(videoId);
+    return this.db
+      .doc<Video>(`users/${uid}/playLists/${listId}/videos/${videoId}`)
+      .delete()
+      .then(() => {
+        this.snackBar.open('動画を削除しました');
+      });
   }
 }

--- a/src/app/video-list/video-list.module.ts
+++ b/src/app/video-list/video-list.module.ts
@@ -1,0 +1,20 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatIconModule } from '@angular/material/icon';
+import { MatMenuModule } from '@angular/material/menu';
+import { VideoListComponent } from './video-list/video-list.component';
+
+@NgModule({
+  declarations: [VideoListComponent],
+  imports: [
+    CommonModule,
+    MatCardModule,
+    MatIconModule,
+    MatMenuModule,
+    MatButtonModule,
+  ],
+  exports: [VideoListComponent],
+})
+export class VideoListModule {}

--- a/src/app/video-list/video-list/video-list.component.html
+++ b/src/app/video-list/video-list/video-list.component.html
@@ -1,0 +1,26 @@
+<a class="video-list" *ngFor="let video of videos$ | async">
+  <figure
+    class="video-list__thumbnail"
+    [style.background-image]="'url(' + video.thumbnailURL + ')'"
+  ></figure>
+  <div class="video-list__contents">
+    <p class="video-list__title">{{ video.title }}</p>
+    <p class="video-list__updated">
+      更新日: {{ video.updatedAt.toDate() | date: 'yyyy/MM/dd' }}
+    </p>
+  </div>
+  <div class="video-list__option-btn" align="end">
+    <button [matMenuTriggerFor]="menu" mat-icon-button>
+      <mat-icon>more_horiz</mat-icon>
+    </button>
+    <mat-menu #menu="matMenu">
+      <button
+        (click)="this.videoService.deleteVideo(uid, listId, video.videoId)"
+        mat-menu-item
+      >
+        <mat-icon>delete</mat-icon>
+        <span>削除</span>
+      </button>
+    </mat-menu>
+  </div>
+</a>

--- a/src/app/video-list/video-list/video-list.component.scss
+++ b/src/app/video-list/video-list/video-list.component.scss
@@ -7,14 +7,15 @@
   overflow: hidden;
   position: relative;
   cursor: pointer;
+  background-color: map_get($mat-grey, 800);
   &:hover {
     @include mat-elevation-transition;
     @include mat-elevation(10);
-    background-color: rgba(#ffffff, 0.1);
+    background-color: rgba(white, 0.04);
   }
   &__thumbnail {
     padding-bottom: 56%;
-    background: #ffffff 50% / cover;
+    background: rgba(black, 0.38) 50% / cover;
   }
   &__contents {
     padding: 16px;
@@ -31,7 +32,7 @@
   }
   &__updated {
     font-size: 12px;
-    color: rgba(255, 255, 255, 0.7);
+    color: $light-secondary-text;
   }
   &__option-btn {
     position: absolute;

--- a/src/app/video-list/video-list/video-list.component.scss
+++ b/src/app/video-list/video-list/video-list.component.scss
@@ -1,0 +1,42 @@
+@import '~@angular/material/theming';
+
+.video-list {
+  @include mat-elevation-transition;
+  @include mat-elevation(2);
+  border-radius: 4px;
+  overflow: hidden;
+  position: relative;
+  cursor: pointer;
+  &:hover {
+    @include mat-elevation-transition;
+    @include mat-elevation(10);
+    background-color: rgba(#ffffff, 0.1);
+  }
+  &__thumbnail {
+    padding-bottom: 56%;
+    background: #ffffff 50% / cover;
+  }
+  &__contents {
+    padding: 16px;
+  }
+  &__title {
+    font-size: 14px;
+    font-weight: 500;
+    color: #ffffff;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    overflow: hidden;
+    margin-bottom: 16px;
+  }
+  &__updated {
+    font-size: 12px;
+    color: rgba(255, 255, 255, 0.7);
+  }
+  &__option-btn {
+    position: absolute;
+    z-index: 1;
+    bottom: 0;
+    right: 0;
+  }
+}

--- a/src/app/video-list/video-list/video-list.component.spec.ts
+++ b/src/app/video-list/video-list/video-list.component.spec.ts
@@ -1,0 +1,24 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { VideoListComponent } from './video-list.component';
+
+describe('VideoListComponent', () => {
+  let component: VideoListComponent;
+  let fixture: ComponentFixture<VideoListComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [VideoListComponent],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(VideoListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/video-list/video-list/video-list.component.ts
+++ b/src/app/video-list/video-list/video-list.component.ts
@@ -12,21 +12,12 @@ import { VideoService } from 'src/app/services/video.service';
 export class VideoListComponent implements OnInit {
   @Input() videos$: Observable<Video[]>;
   @Input() listId: string;
-  videos: Video[];
   uid = this.authService.uid;
-
-  private subscriptions: Subscription = new Subscription();
 
   constructor(
     private authService: AuthService,
     public videoService: VideoService
   ) {}
 
-  ngOnInit(): void {
-    this.subscriptions.add(
-      this.videos$.subscribe((videos) => {
-        this.videos = videos;
-      })
-    );
-  }
+  ngOnInit(): void {}
 }

--- a/src/app/video-list/video-list/video-list.component.ts
+++ b/src/app/video-list/video-list/video-list.component.ts
@@ -1,0 +1,32 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { Observable, Subscription } from 'rxjs';
+import { Video } from 'src/app/interfaces/video';
+import { AuthService } from 'src/app/services/auth.service';
+import { VideoService } from 'src/app/services/video.service';
+
+@Component({
+  selector: 'app-video-list',
+  templateUrl: './video-list.component.html',
+  styleUrls: ['./video-list.component.scss'],
+})
+export class VideoListComponent implements OnInit {
+  @Input() videos$: Observable<Video[]>;
+  @Input() listId: string;
+  videos: Video[];
+  uid = this.authService.uid;
+
+  private subscriptions: Subscription = new Subscription();
+
+  constructor(
+    private authService: AuthService,
+    public videoService: VideoService
+  ) {}
+
+  ngOnInit(): void {
+    this.subscriptions.add(
+      this.videos$.subscribe((videos) => {
+        this.videos = videos;
+      })
+    );
+  }
+}


### PR DESCRIPTION
fix #61 
追加した動画の一覧コンポーネント作成と動画の削除機能を実装しました！
作業内容は以下の通りになります。ご確認よろしくお願い致します！

## 実装内容

- video-listのmodule、componentの作成をしました。レイアウトをplay-list-detailでしたのでそれに伴い、プレイリストの詳細画面のレイアウトを少し変更しました。

- 動画追加時にAPIから取得していたURLのサイズを変更しました。

- interfaceのVideoにcreatorIdが存在していなかったので、動画削除時にpermission errorが出てしまっていたのを修正しました(VideoにcreatorIdを追加)

- 詳細画面に遷移したタイミングでドロワーが閉じる様に実装しました。
それに伴ってドロワー周りのリファクタリングをしました。

- その他videoのデータを受け取る設計などを変更や不要コードの削除も見つけた範囲で行いました。

## image
[![Image from Gyazo](https://i.gyazo.com/9d92227d15e39a48f710f3ba66c7b39e.gif)](https://gyazo.com/9d92227d15e39a48f710f3ba66c7b39e)